### PR TITLE
cleanup .travis.yml and associated files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,60 +1,36 @@
+sudo: required
+
 language: go
 
 env:
-  global:
-  - secure: "cdE3p1PuSBF6pwGCg49Ji/YG1ijfulYaXxSeVos+8TEiI1ePwsHZ+jpZM3OAPGiC5h9U2F1mAxD/gXBjEHBXBTMj04r8XfFM82qMClEArYbGvE2+1HPOE4ZRBZmLQZVjuGth1mRpDvCZLIyNHKczbaL0AtyT3e7ekdZ7MGwowDQ="
   matrix:
   - BLAS_LIB=OpenBLAS
-  #- BLAS_LIB=Accellerate
-  # at some point, when the issue with drotgm is resolved
-  #- BLAS_LIB=ATLAS
+  - BLAS_LIB=gonum
+  # Does not currently link correctly.  Note that there is an issue with drotgm in ATLAS.
+  # - BLAS_LIB=ATLAS 
+  # If we can get multiarch builds on travis.
+  # There are some issues with the Accellerate implementation.
+  #- BLAS_LIB=Accellerate 
 
-
+# Versions of go that are explicitly supported by gonum.
 go:
  - 1.3.3
  - 1.4.2
- - tip
 
+# Required for coverage.
 before_install:
- - sudo apt-get update -qq
- - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+ - go get golang.org/x/tools/cmd/cover
+ - go get github.com/mattn/goveralls
 
-
+# Install the appropriate BLAS library.
 install:
- - if [[ "$BLAS_LIB" == "ATLAS" ]]; then sudo apt-get install -qq libatlas-base-dev; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then sudo apt-get install -qq gfortran; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then pushd ~; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then sudo git clone --depth=1 git://github.com/xianyi/OpenBLAS; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then pushd OpenBLAS; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then sudo make FC=gfortran &> /dev/null; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then sudo make PREFIX=/usr install; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then popd; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then curl http://www.netlib.org/blas/blast-forum/cblas.tgz | tar -zx; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then pushd CBLAS; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then sudo mv Makefile.LINUX Makefile.in; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then sudo BLLIB=/usr/lib/libopenblas.a make alllib; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then sudo mv lib/cblas_LINUX.a /usr/lib/libcblas.a; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then popd; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then popd; fi
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then export CGO_LDFLAGS="-L/usr/lib -lopenblas"; fi
- - go get github.com/gonum/blas
- - go get github.com/gonum/matrix/mat64
- - pushd cgo
- - if [[ "$BLAS_LIB" == "OpenBLAS" ]]; then perl genLapack.pl -L/usr/lib -lopenblas; fi
- - popd
- 
+ - bash .travis/$TRAVIS_OS_NAME/$BLAS_LIB/install.sh
+
+# Get deps, build, test, and ensure the code is gofmt'ed.
+# If we are building as gonum, then we have access to the coveralls api key, so we can run coverage as well.
 script:
  - go get -d -t -v ./...
- - go test -x -v ./...
- - diff <(gofmt -d .) <("")
- - if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then bash test-coverage.sh; fi
- 
-
-after_failure: failure
-
-notifications:
-  email:
-    recipients:
-      - jonathan.lawlor@gmail.com
-    on_success: change
-    on_failure: always
+ - go build -v ./...
+ - go test -v ./...
+ - diff <(gofmt -d *.go) <("")
+ - if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then bash .travis/test-coverage.sh; fi

--- a/.travis/linux/ATLAS/install.sh
+++ b/.travis/linux/ATLAS/install.sh
@@ -1,0 +1,11 @@
+sudo apt-get update -qq
+sudo apt-get install -qq libatlas-base-dev
+
+export CGO_LDFLAGS="-L/usr/lib -latlas -llapack_atlas"
+
+go get github.com/gonum/blas
+go get github.com/gonum/matrix/mat64
+
+pushd cgo
+sudo perl genLapack.pl -L/usr/lib -latlas -llapack_atlas
+popd

--- a/.travis/linux/OpenBLAS/install.sh
+++ b/.travis/linux/OpenBLAS/install.sh
@@ -1,0 +1,23 @@
+sudo apt-get update -qq
+sudo apt-get install -qq gfortran
+pushd ~
+sudo git clone --depth=1 git://github.com/xianyi/OpenBLAS
+pushd OpenBLAS
+sudo make FC=gfortran &> /dev/null
+sudo make PREFIX=/usr install
+popd
+curl http://www.netlib.org/blas/blast-forum/cblas.tgz | tar -zx
+pushd CBLAS
+sudo mv Makefile.LINUX Makefile.in
+sudo BLLIB=/usr/lib/libopenblas.a make alllib
+sudo mv lib/cblas_LINUX.a /usr/lib/libcblas.a
+popd
+popd
+export CGO_LDFLAGS="-L/usr/lib -lopenblas"
+
+go get github.com/gonum/blas
+go get github.com/gonum/matrix/mat64
+
+pushd cgo
+sudo perl genLapack.pl -L/usr/lib -lopenblas
+popd

--- a/.travis/linux/gonum/install.sh
+++ b/.travis/linux/gonum/install.sh
@@ -1,0 +1,2 @@
+go get github.com/gonum/blas
+go get github.com/gonum/matrix/mat64

--- a/.travis/test-coverage.sh
+++ b/.travis/test-coverage.sh
@@ -10,13 +10,13 @@ if [[ ${returnval} != *FAIL* ]]
 then
 	if [ -f profile.out ]
 	then
-		cat profile.out | grep -v "mode: set" >> acc.out 
+		cat profile.out | grep -v "mode: set" >> acc.out
 	fi
 else
 	exit 1
-fi	
+fi
 
-for Dir in $(find ./* -maxdepth 10 -type d ); 
+for Dir in $(find ./* -maxdepth 10 -type d );
 do
 	if ls $Dir/*.go &> /dev/null;
 	then
@@ -27,16 +27,17 @@ do
 		then
     		if [ -f profile.out ]
     		then
-        		cat profile.out | grep -v "mode: set" >> acc.out 
+        		cat profile.out | grep -v "mode: set" >> acc.out
     		fi
     	else
     		exit 1
-    	fi	
+    	fi
     fi
 done
 if [ -n "$COVERALLS_TOKEN" ]
 then
 	$HOME/gopath/bin/goveralls -coverprofile=acc.out -service=travis-ci -repotoken $COVERALLS_TOKEN
-fi	
+fi
 
 rm -rf ./profile.out
+rm -rf ./acc.out


### PR DESCRIPTION
As explained in
https://groups.google.com/d/msg/gonum-dev/GKJjAtDxR9I/n0FD7WvvN5AJ

Removed notifications and go tip, simplified code, added some comments,
put all travis related code (except for .travis.yml) into .travis/

A note for discussion: I named the build that relies on gonum/blas "gonum," where previously we have called it native, because native is typically used to describe something that is processor dependent and not portable, while the gonum/blas library is the opposite.  I also fiddled around a little with getting the ATLAS build to work, but I was having issues linking the lapack functions so its install script is not complete.  It is not enabled for builds, although it would be nice because it takes much less time to install.

PTAL