### PR TITLE
Put lapack.go in gitignore

### DIFF
--- a/cgo/.gitignore
+++ b/cgo/.gitignore
@@ -1,0 +1,1 @@
+lapack.go


### PR DESCRIPTION
Otherwise, this directory is always dirty after a Go build when
gonum/lapack is consumed as a submodule.