### PR TITLE
internal/fortran: new package - conversion utilities

### DIFF
--- a/internal/fortran/fortran.go
+++ b/internal/fortran/fortran.go
@@ -1,0 +1,476 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package fortran provides utilities to help interface to fortran routines.
+//
+// The utility functions provided in fortran are not intended to be used generally
+// and provide very limited friendliness. They are intended to be used in development
+// of Go ports of FORTRAN routines.
+package fortran
+
+import (
+	"github.com/gonum/blas"
+	"github.com/gonum/blas/blas64"
+)
+
+// TransCharacter returns the FORTRAN character for the given transpose operation.
+func TransCharacter(trans blas.Transpose) byte {
+	switch trans {
+	case blas.NoTrans:
+		return 'N'
+	case blas.Trans:
+		return 'T'
+	case blas.ConjTrans:
+		return 'C'
+	default:
+		panic("fortran: bad BLAS trans")
+	}
+}
+
+// UploCharacter returns the FORTRAN character for the given uplo state.
+func UploCharacter(uplo blas.Uplo) byte {
+	switch uplo {
+	case blas.Upper:
+		return 'U'
+	case blas.Lower:
+		return 'L'
+	case blas.All:
+		return 'A'
+	default:
+		panic("fortran: bad BLAS uplo")
+	}
+}
+
+// DiagCharacter returns the FORTRAN character for the given diagonal state.
+func DiagCharacter(diag blas.Diag) byte {
+	switch diag {
+	case blas.Unit:
+		return 'U'
+	case blas.NonUnit:
+		return 'N'
+	default:
+		panic("fortran: bad BLAS diag")
+	}
+}
+
+// SideCharacter returns the FORTRAN character for the given side state.
+func SideCharacter(side blas.Side) byte {
+	switch side {
+	case blas.Left:
+		return 'L'
+	case blas.Right:
+		return 'R'
+	default:
+		panic("fortran: bad BLAS side")
+	}
+}
+
+// General is a column major general matrix.
+type General blas64.General
+
+// NewColMajorGeneralFrom returns a column major general matrix
+// with the same dimensions and data elements as the row major a.
+func NewColMajorGeneralFrom(a blas64.General) General {
+	t := General{
+		Rows:   a.Rows,
+		Cols:   a.Cols,
+		Stride: a.Rows,
+		Data:   make([]float64, a.Rows*a.Cols),
+	}
+	t.From(a)
+	return t
+}
+
+// From fills the receiver with elements from a. The receiver
+// must have the same dimensions as a and have adequate backing
+// data storage.
+func (t General) From(a blas64.General) {
+	if t.Rows != a.Rows || t.Cols != a.Cols {
+		panic("fortran: mismatched dimension")
+	}
+	if len(t.Data) < (t.Cols-1)*t.Stride+t.Rows {
+		panic("fortran: short data slice")
+	}
+	for i := 0; i < a.Rows; i++ {
+		for j := 0; j < a.Cols; j++ {
+			t.Data[i+j*t.Stride] = a.Data[i*a.Stride+j]
+		}
+	}
+}
+
+// NewRowMajorGeneralFrom returns a row major general matrix
+// with the same dimensions and data elements as a column major a.
+func NewRowMajorGeneralFrom(a General) blas64.General {
+	t := blas64.General{
+		Rows:   a.Rows,
+		Cols:   a.Cols,
+		Stride: a.Cols,
+		Data:   make([]float64, a.Rows*a.Cols),
+	}
+	a.To(t)
+	return t
+}
+
+// To fills t with elements from the receiver. The blas64.General
+// must have the same dimensions as a and have adequate backing
+// data storage.
+func (a General) To(t blas64.General) {
+	if t.Rows != a.Rows || t.Cols != a.Cols {
+		panic("fortran: mismatched dimension")
+	}
+	if len(t.Data) < (t.Rows-1)*t.Stride+t.Cols {
+		panic("fortran: short data slice")
+	}
+	for i := 0; i < a.Cols; i++ {
+		for j := 0; j < a.Rows; j++ {
+			t.Data[i+j*t.Stride] = a.Data[i*a.Stride+j]
+		}
+	}
+}
+
+// CopyGeneralRowMajor performs a copy of src to dst which are
+// row major matrices. The dimensions of src and dst must match
+// and dst must have adequate data storage, otherwise CopyGeneralRowMajor
+// will panic.
+func CopyGeneralRowMajor(dst, src blas64.General) {
+	if dst.Rows != src.Rows || dst.Cols != src.Cols {
+		panic("fortran: mismatched dimension")
+	}
+	if len(dst.Data) < (dst.Rows-1)*dst.Stride+dst.Cols {
+		panic("fortran: short data slice")
+	}
+	for i := 0; i < src.Rows; i++ {
+		for j := 0; j < src.Cols; j++ {
+			dst.Data[i*dst.Stride+j] = src.Data[i*src.Stride+j]
+		}
+	}
+}
+
+// CopyGeneralColMajor performs a copy of src to dst which are
+// column major matrices. The dimensions of src and dst must match
+// and dst must have adequate data storage, otherwise CopyGeneralRowMajor
+// will panic.
+func CopyGeneralColMajor(dst, src General) {
+	if dst.Rows != src.Rows || dst.Cols != src.Cols {
+		panic("fortran: mismatched dimension")
+	}
+	if len(dst.Data) < (dst.Cols-1)*dst.Stride+dst.Rows {
+		panic("fortran: short data slice")
+	}
+	for j := 0; j < src.Cols; j++ {
+		for i := 0; i < src.Rows; i++ {
+			dst.Data[i+j*dst.Stride] = src.Data[i+j*src.Stride]
+		}
+	}
+}
+
+// Symmetric is a column major symmetric matrix.
+type Symmetric blas64.Symmetric
+
+// NewColMajorSymmetricFrom returns a column major symmetric matrix
+// with the same dimensions and data elements as the row major a.
+func NewColMajorSymmetricFrom(a blas64.Symmetric) Symmetric {
+	t := Symmetric{
+		N:      a.N,
+		Stride: a.N,
+		Data:   make([]float64, a.N*a.N),
+		Uplo:   a.Uplo,
+	}
+	t.From(a)
+	return t
+}
+
+// From fills the receiver with elements from a. The receiver
+// must have the same dimensions as a and have adequate backing
+// data storage.
+func (t Symmetric) From(a blas64.Symmetric) {
+	switch a.Uplo {
+	case blas.Upper:
+		for i := 0; i < a.N; i++ {
+			for j := i; j < a.N; j++ {
+				t.Data[i+j*t.Stride] = a.Data[i*a.Stride+j]
+			}
+		}
+	case blas.Lower:
+		for i := 0; i < a.N; i++ {
+			for j := 0; j <= i; j++ {
+				t.Data[i+j*t.Stride] = a.Data[i*a.Stride+j]
+			}
+		}
+	default:
+		panic("fortran: bad BLAS uplo")
+	}
+}
+
+// NewRowMajorSymmetricFrom returns a row major symmetric matrix
+// with the same dimensions and data elements as the col major a.
+func NewRowMajorSymmetricFrom(a Symmetric) blas64.Symmetric {
+	t := blas64.Symmetric{
+		N:      a.N,
+		Stride: a.N,
+		Data:   make([]float64, a.N*a.N),
+		Uplo:   a.Uplo,
+	}
+	a.To(t)
+	return t
+}
+
+// To fills t with elements from the receiver. The blas64.Symmetric
+// must have the same dimensions as a and have adequate backing
+// data storage.
+func (a Symmetric) To(t blas64.Symmetric) {
+	switch a.Uplo {
+	case blas.Upper:
+		for i := 0; i < a.N; i++ {
+			for j := i; j < a.N; j++ {
+				t.Data[i*t.Stride+j] = a.Data[i+j*a.Stride]
+			}
+		}
+	case blas.Lower:
+		for i := 0; i < a.N; i++ {
+			for j := 0; j <= i; j++ {
+				t.Data[i*t.Stride+j] = a.Data[i+j*a.Stride]
+			}
+		}
+	default:
+		panic("fortran: bad BLAS uplo")
+	}
+}
+
+// CopySymmetricRowMajor performs a copy of src to dst which are
+// row major matrices. The dimensions and shape of src and dst must match
+// and dst must have adequate data storage, otherwise CopyTriangularRowMajor
+// will panic.
+func CopySymmetricRowMajor(dst, src blas64.Symmetric) {
+	if dst.N != src.N {
+		panic("fortran: mismatched dimension")
+	}
+	if dst.Uplo != src.Uplo {
+		panic("fortran: mismatched BLAS uplo")
+	}
+	if len(dst.Data) < (dst.N-1)*dst.Stride+dst.N {
+		panic("fortran: short data slice")
+	}
+	switch src.Uplo {
+	case blas.Upper:
+		for i := 0; i < src.N; i++ {
+			for j := i; j < src.N; j++ {
+				dst.Data[i*dst.Stride+j] = src.Data[i*src.Stride+j]
+			}
+		}
+	case blas.Lower:
+		for i := 0; i < src.N; i++ {
+			for j := 0; j <= i; j++ {
+				dst.Data[i*dst.Stride+j] = src.Data[i*src.Stride+j]
+			}
+		}
+	default:
+		panic("fortran: bad BLAS uplo")
+	}
+}
+
+// CopySymmetricColMajor performs a copy of src to dst which are
+// column major matrices. The dimensions and shape of src and dst must match
+// and dst must have adequate data storage, otherwise CopySymmetricColMajor
+// will panic.
+func CopySymmetricColMajor(dst, src Symmetric) {
+	if dst.N != src.N {
+		panic("fortran: mismatched dimension")
+	}
+	if dst.Uplo != src.Uplo {
+		panic("fortran: mismatched BLAS uplo")
+	}
+	if len(dst.Data) < (dst.N-1)*dst.Stride+dst.N {
+		panic("fortran: short data slice")
+	}
+	switch src.Uplo {
+	case blas.Upper:
+		for i := 0; i < src.N; i++ {
+			for j := i; j < src.N; j++ {
+				dst.Data[i+j*dst.Stride] = src.Data[i+j*src.Stride]
+			}
+		}
+	case blas.Lower:
+		for i := 0; i < src.N; i++ {
+			for j := 0; j <= i; j++ {
+				dst.Data[i+j*dst.Stride] = src.Data[i+j*src.Stride]
+			}
+		}
+	default:
+		panic("fortran: bad BLAS uplo")
+	}
+}
+
+// Triangular is a column major triangular matrix.
+type Triangular blas64.Triangular
+
+// NewColMajorTriangularFrom returns a column major general matrix
+// with the same dimensions and data elements as the row major a.
+func NewColMajorTriangularFrom(a blas64.Triangular) Triangular {
+	t := Triangular{
+		N:      a.N,
+		Stride: a.N,
+		Data:   make([]float64, a.N*a.N),
+		Diag:   a.Diag,
+		Uplo:   a.Uplo,
+	}
+	t.From(a)
+	return t
+}
+
+// From fills the receiver with elements from a. The receiver
+// must have the same dimensions as a and have adequate backing
+// data storage.
+func (t Triangular) From(a blas64.Triangular) {
+	switch a.Uplo {
+	case blas.Upper:
+		for i := 0; i < a.N; i++ {
+			for j := i; j < a.N; j++ {
+				t.Data[i+j*t.Stride] = a.Data[i*a.Stride+j]
+			}
+		}
+	case blas.Lower:
+		for i := 0; i < a.N; i++ {
+			for j := 0; j <= i; j++ {
+				t.Data[i+j*t.Stride] = a.Data[i*a.Stride+j]
+			}
+		}
+	case blas.All:
+		for i := 0; i < a.N; i++ {
+			for j := 0; j < a.N; j++ {
+				t.Data[i+j*t.Stride] = a.Data[i*a.Stride+j]
+			}
+		}
+	default:
+		panic("fortran: bad BLAS uplo")
+	}
+}
+
+// NewRowMajorTriangularFrom returns a row major triangular matrix
+// with the same dimensions and data elements as a column major a.
+func NewRowMajorTriangularFrom(a Triangular) blas64.Triangular {
+	t := blas64.Triangular{
+		N:      a.N,
+		Stride: a.N,
+		Data:   make([]float64, a.N*a.N),
+		Diag:   a.Diag,
+		Uplo:   a.Uplo,
+	}
+	a.To(t)
+	return t
+}
+
+// To fills t with elements from the receiver. The blas64.Triangular
+// must have the same dimensions as a and have adequate backing
+// data storage.
+func (a Triangular) To(t blas64.Triangular) {
+	switch a.Uplo {
+	case blas.Upper:
+		for i := 0; i < a.N; i++ {
+			for j := i; j < a.N; j++ {
+				t.Data[i*t.Stride+j] = a.Data[i+j*a.Stride]
+			}
+		}
+	case blas.Lower:
+		for i := 0; i < a.N; i++ {
+			for j := 0; j <= i; j++ {
+				t.Data[i*t.Stride+j] = a.Data[i+j*a.Stride]
+			}
+		}
+	case blas.All:
+		for i := 0; i < a.N; i++ {
+			for j := 0; j < a.N; j++ {
+				t.Data[i*t.Stride+j] = a.Data[i+j*a.Stride]
+			}
+		}
+	default:
+		panic("fortran: bad BLAS uplo")
+	}
+}
+
+// CopyTriangularRowMajor performs a copy of src to dst which are
+// row major matrices. The dimensions and shape of src and dst must match
+// and dst must have adequate data storage, otherwise CopyTriangularRowMajor
+// will panic. The value of src.Diag is checked for matching with dst.Diag,
+// but does not alter the behavior of the copy; the underlying data is
+// always copied.
+func CopyTriangularRowMajor(dst, src blas64.Triangular) {
+	if dst.N != src.N {
+		panic("fortran: mismatched dimension")
+	}
+	if dst.Diag != src.Diag {
+		panic("fortran: mismatched BLAS diag")
+	}
+	if dst.Uplo != src.Uplo {
+		panic("fortran: mismatched BLAS uplo")
+	}
+	if len(dst.Data) < (dst.N-1)*dst.Stride+dst.N {
+		panic("fortran: short data slice")
+	}
+	switch src.Uplo {
+	case blas.Upper:
+		for i := 0; i < src.N; i++ {
+			for j := i; j < src.N; j++ {
+				dst.Data[i*dst.Stride+j] = src.Data[i*src.Stride+j]
+			}
+		}
+	case blas.Lower:
+		for i := 0; i < src.N; i++ {
+			for j := 0; j <= i; j++ {
+				dst.Data[i*dst.Stride+j] = src.Data[i*src.Stride+j]
+			}
+		}
+	case blas.All:
+		for i := 0; i < src.N; i++ {
+			for j := 0; j < src.N; j++ {
+				dst.Data[i*dst.Stride+j] = src.Data[i*src.Stride+j]
+			}
+		}
+	default:
+		panic("fortran: bad BLAS uplo")
+	}
+}
+
+// CopyTriangularColMajor performs a copy of src to dst which are
+// column major matrices. The dimensions and shape of src and dst must match
+// and dst must have adequate data storage, otherwise CopyTriangularColMajor
+// will panic. The value of src.Diag is checked for matching with dst.Diag,
+// but does not alter the behavior of the copy; the underlying data is
+// always copied.
+func CopyTriangularColMajor(dst, src Triangular) {
+	if dst.N != src.N {
+		panic("fortran: mismatched dimension")
+	}
+	if dst.Diag != src.Diag {
+		panic("fortran: mismatched BLAS diag")
+	}
+	if dst.Uplo != src.Uplo {
+		panic("fortran: mismatched BLAS uplo")
+	}
+	if len(dst.Data) < (dst.N-1)*dst.Stride+dst.N {
+		panic("fortran: short data slice")
+	}
+	switch src.Uplo {
+	case blas.Upper:
+		for i := 0; i < src.N; i++ {
+			for j := i; j < src.N; j++ {
+				dst.Data[i+j*dst.Stride] = src.Data[i+j*src.Stride]
+			}
+		}
+	case blas.Lower:
+		for i := 0; i < src.N; i++ {
+			for j := 0; j <= i; j++ {
+				dst.Data[i+j*dst.Stride] = src.Data[i+j*src.Stride]
+			}
+		}
+	case blas.All:
+		for i := 0; i < src.N; i++ {
+			for j := 0; j < src.N; j++ {
+				dst.Data[i+j*dst.Stride] = src.Data[i+j*src.Stride]
+			}
+		}
+	default:
+		panic("fortran: bad BLAS uplo")
+	}
+}

--- a/internal/fortran/fortran_test.go
+++ b/internal/fortran/fortran_test.go
@@ -1,0 +1,572 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fortran
+
+import (
+	"math"
+	"testing"
+
+	"github.com/gonum/blas"
+	"github.com/gonum/blas/blas64"
+)
+
+type general interface {
+	dims() (r, c int)
+	at(r, c int) float64
+}
+
+type rowMajorGeneral blas64.General
+
+func (m rowMajorGeneral) dims() (r, c int)    { return m.Rows, m.Cols }
+func (m rowMajorGeneral) at(r, c int) float64 { return m.Data[r*m.Stride+c] }
+
+type colMajorGeneral blas64.General
+
+func (m colMajorGeneral) dims() (r, c int)    { return m.Rows, m.Cols }
+func (m colMajorGeneral) at(r, c int) float64 { return m.Data[r+c*m.Stride] }
+
+func equalGeneral(a, b general) bool {
+	ar, ac := a.dims()
+	br, bc := b.dims()
+	if ar != br || ac != bc {
+		return false
+	}
+	for i := 0; i < ar; i++ {
+		for j := 0; j < ac; j++ {
+			if a.at(i, j) != b.at(i, j) || math.IsNaN(a.at(i, j)) != math.IsNaN(b.at(i, j)) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+var generalTests = []blas64.General{
+	{Rows: 2, Cols: 3, Stride: 3, Data: []float64{
+		1, 2, 3,
+		4, 5, 6,
+	}},
+	{Rows: 3, Cols: 2, Stride: 2, Data: []float64{
+		1, 2,
+		3, 4,
+		5, 6,
+	}},
+	{Rows: 3, Cols: 3, Stride: 3, Data: []float64{
+		1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+	}},
+	{Rows: 2, Cols: 3, Stride: 5, Data: []float64{
+		1, 2, 3, 0, 0,
+		4, 5, 6, 0, 0,
+	}},
+	{Rows: 3, Cols: 2, Stride: 5, Data: []float64{
+		1, 2, 0, 0, 0,
+		3, 4, 0, 0, 0,
+		5, 6, 0, 0, 0,
+	}},
+	{Rows: 3, Cols: 3, Stride: 5, Data: []float64{
+		1, 2, 3, 0, 0,
+		4, 5, 6, 0, 0,
+		7, 8, 9, 0, 0,
+	}},
+}
+
+func TestConvertGeneral(t *testing.T) {
+	for _, test := range generalTests {
+		colmajor := NewColMajorGeneralFrom(test)
+		if !equalGeneral(colMajorGeneral(colmajor), rowMajorGeneral(test)) {
+			t.Errorf("unexpected result for row major to col major conversion:\n\tgot: %+v\n\tfrom:%+v",
+				colmajor, test)
+		}
+		rowmajor := NewRowMajorGeneralFrom(colmajor)
+		if !equalGeneral(rowMajorGeneral(rowmajor), rowMajorGeneral(test)) {
+			t.Errorf("unexpected result for row major to col major conversion:\n\tgot: %+v\n\twant:%+v",
+				rowmajor, test)
+		}
+	}
+}
+
+func TestCopyGeneralRowMajor(t *testing.T) {
+	for _, test := range generalTests {
+		src := test
+		for stride := src.Cols; stride <= src.Stride+1; stride++ {
+			dst := blas64.General{
+				Rows:   src.Rows,
+				Cols:   src.Cols,
+				Stride: stride,
+				Data:   make([]float64, src.Rows*stride),
+			}
+			for i := range dst.Data {
+				dst.Data[i] = math.NaN()
+			}
+			CopyGeneralRowMajor(dst, src)
+			if !equalGeneral(rowMajorGeneral(dst), rowMajorGeneral(src)) {
+				t.Errorf("unexpected result for row major copy:\n\tgot: %+v\n\tfrom:%+v",
+					dst, src)
+			}
+			// We are abusing the indexing to see outside the real data.
+			for i := 0; i < dst.Rows; i++ {
+				for j := dst.Cols; j < dst.Stride; j++ {
+					if !math.IsNaN(rowMajorGeneral(dst).at(i, j)) {
+						t.Errorf("unexpected result for row major copy value overwritten at (%d,%d):\n\tgot: %+v\n\tfrom:%+v",
+							i, j, dst, src)
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestCopyGeneralColMajor(t *testing.T) {
+	for _, test := range generalTests {
+		src := NewColMajorGeneralFrom(test)
+		for stride := src.Rows; stride <= src.Stride+1; stride++ {
+			dst := General{
+				Rows:   src.Rows,
+				Cols:   src.Cols,
+				Stride: stride,
+				Data:   make([]float64, src.Cols*stride),
+			}
+			for i := range dst.Data {
+				dst.Data[i] = math.NaN()
+			}
+			CopyGeneralColMajor(dst, src)
+			if !equalGeneral(colMajorGeneral(dst), colMajorGeneral(src)) {
+				t.Errorf("unexpected result for col major copy:\n\tgot: %+v\n\tfrom:%+v",
+					dst, src)
+			}
+			// We are abusing the indexing to see outside the real data.
+			for i := dst.Rows; i < dst.Stride; i++ {
+				for j := 0; j < dst.Cols; j++ {
+					if !math.IsNaN(colMajorGeneral(dst).at(i, j)) {
+						t.Errorf("unexpected result for col major copy value overwritten at (%d,%d):\n\tgot: %+v\n\tfrom:%+v",
+							i, j, dst, src)
+					}
+				}
+			}
+		}
+	}
+}
+
+type symmetric interface {
+	n() int
+	at(r, c int) float64
+	uplo() blas.Uplo
+}
+
+type rowMajorSymmetric blas64.Symmetric
+
+func (m rowMajorSymmetric) n() int { return m.N }
+func (m rowMajorSymmetric) at(r, c int) float64 {
+	if m.Uplo == blas.Lower && r < c && c < m.N {
+		r, c = c, r
+	}
+	if m.Uplo == blas.Upper && r > c {
+		r, c = c, r
+	}
+	return m.Data[r*m.Stride+c]
+}
+
+// atOK is at, but always returns the actual stored value and
+// a boolean indicating whether it is a valid element.
+func (m rowMajorSymmetric) atOK(r, c int) (v float64, ok bool) {
+	ok = true
+	if m.Uplo == blas.Lower && r < c && c < m.N {
+		ok = false
+	}
+	if m.Uplo == blas.Upper && r > c {
+		ok = false
+	}
+	return m.Data[r*m.Stride+c], ok
+}
+func (m rowMajorSymmetric) uplo() blas.Uplo { return m.Uplo }
+
+type colMajorSymmetric blas64.Symmetric
+
+func (m colMajorSymmetric) n() int { return m.N }
+func (m colMajorSymmetric) at(r, c int) float64 {
+	if m.Uplo == blas.Lower && r < c {
+		r, c = c, r
+	}
+	if m.Uplo == blas.Upper && r > c && r < m.N {
+		r, c = c, r
+	}
+	return m.Data[r+c*m.Stride]
+}
+
+// atOK is at, but always returns the actual stored value and
+// a boolean indicating whether it is a valid element.
+func (m colMajorSymmetric) atOK(r, c int) (v float64, ok bool) {
+	ok = true
+	if m.Uplo == blas.Lower && r < c {
+		ok = false
+	}
+	if m.Uplo == blas.Upper && r > c && r < m.N {
+		ok = false
+	}
+	return m.Data[r+c*m.Stride], ok
+}
+func (m colMajorSymmetric) uplo() blas.Uplo { return m.Uplo }
+
+func equalSymmetric(a, b symmetric) bool {
+	an := a.n()
+	bn := b.n()
+	if an != bn {
+		return false
+	}
+	for i := 0; i < an; i++ {
+		for j := 0; j < an; j++ {
+			if a.at(i, j) != b.at(i, j) || math.IsNaN(a.at(i, j)) != math.IsNaN(b.at(i, j)) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+var symmetricTests = []blas64.Symmetric{
+	{N: 3, Stride: 3, Data: []float64{
+		1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+	}},
+	{N: 3, Stride: 5, Data: []float64{
+		1, 2, 3, 0, 0,
+		4, 5, 6, 0, 0,
+		7, 8, 9, 0, 0,
+	}},
+}
+
+func TestConvertSymmetric(t *testing.T) {
+	for _, test := range symmetricTests {
+		for _, uplo := range []blas.Uplo{blas.Upper, blas.Lower} {
+			test.Uplo = uplo
+			colmajor := NewColMajorSymmetricFrom(test)
+			if !equalSymmetric(colMajorSymmetric(colmajor), rowMajorSymmetric(test)) {
+				t.Errorf("unexpected result for row major to col major conversion:\n\tgot: %+v\n\tfrom:%+v",
+					colmajor, test)
+			}
+			rowmajor := NewRowMajorSymmetricFrom(colmajor)
+			if !equalSymmetric(rowMajorSymmetric(rowmajor), rowMajorSymmetric(test)) {
+				t.Errorf("unexpected result for row major to col major conversion:\n\tgot: %+v\n\twant:%+v",
+					rowmajor, test)
+			}
+		}
+	}
+}
+
+func TestCopySymmetricRowMajor(t *testing.T) {
+	for _, test := range symmetricTests {
+		for _, uplo := range []blas.Uplo{blas.Upper, blas.Lower} {
+			src := test
+			src.Uplo = uplo
+			for stride := src.N; stride <= src.Stride+1; stride++ {
+				dst := blas64.Symmetric{
+					N:      src.N,
+					Stride: stride,
+					Data:   make([]float64, src.N*stride),
+					Uplo:   src.Uplo,
+				}
+				for i := range dst.Data {
+					dst.Data[i] = math.NaN()
+				}
+				CopySymmetricRowMajor(dst, src)
+				if !equalSymmetric(rowMajorSymmetric(dst), rowMajorSymmetric(src)) {
+					t.Errorf("unexpected result for row major copy:\n\tgot: %+v\n\tfrom:%+v",
+						dst, src)
+				}
+				// We are abusing the indexing to see outside the real data.
+				for i := 0; i < dst.N; i++ {
+					for j := dst.N; j < dst.Stride; j++ {
+						if !math.IsNaN(rowMajorSymmetric(dst).at(i, j)) {
+							t.Errorf("unexpected result for row major copy value overwritten at (%d,%d):\n\tgot: %+v\n\tfrom:%+v",
+								i, j, dst, src)
+						}
+					}
+				}
+
+				// Now check the invalid triangle for overwrites.
+				for i := 0; i < dst.N; i++ {
+					for j := 0; j < dst.N; j++ {
+						v, ok := rowMajorSymmetric(dst).atOK(i, j)
+						if !ok && !math.IsNaN(v) {
+							t.Errorf("unexpected result for row major copy value overwritten at (%d,%d):\n\tgot: %+v\n\tfrom:%+v",
+								i, j, dst, src)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestCopySymmetricColMajor(t *testing.T) {
+	for _, test := range symmetricTests {
+		for _, uplo := range []blas.Uplo{blas.Upper, blas.Lower} {
+			test.Uplo = uplo
+			src := NewColMajorSymmetricFrom(test)
+			for stride := src.N; stride <= src.Stride+1; stride++ {
+				dst := Symmetric{
+					N:      src.N,
+					Stride: stride,
+					Data:   make([]float64, src.N*stride),
+					Uplo:   src.Uplo,
+				}
+				for i := range dst.Data {
+					dst.Data[i] = math.NaN()
+				}
+				CopySymmetricColMajor(dst, src)
+				if !equalSymmetric(colMajorSymmetric(dst), colMajorSymmetric(src)) {
+					t.Errorf("unexpected result for col major copy:\n\tgot: %+v\n\tfrom:%+v",
+						dst, src)
+				}
+				// We are abusing the indexing to see outside the real data.
+				for i := dst.N; i < dst.Stride; i++ {
+					for j := 0; j < dst.N; j++ {
+						if !math.IsNaN(colMajorSymmetric(dst).at(i, j)) {
+							t.Errorf("unexpected result for row major copy value overwritten at (%d,%d):\n\tgot: %+v\n\tfrom:%+v",
+								i, j, dst, src)
+						}
+					}
+				}
+
+				// Now check the invalid triangle for overwrites.
+				for i := 0; i < dst.N; i++ {
+					for j := 0; j < dst.N; j++ {
+						v, ok := colMajorSymmetric(dst).atOK(i, j)
+						if !ok && !math.IsNaN(v) {
+							t.Errorf("unexpected result for row major copy value overwritten at (%d,%d):\n\tgot: %+v\n\tfrom:%+v",
+								i, j, dst, src)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+type triangular interface {
+	n() int
+	at(r, c int) float64
+	uplo() blas.Uplo
+	diag() blas.Diag
+}
+
+type rowMajorTriangular blas64.Triangular
+
+func (m rowMajorTriangular) n() int { return m.N }
+func (m rowMajorTriangular) at(r, c int) float64 {
+	if m.Diag == blas.Unit && r == c {
+		return 1
+	}
+	if m.Uplo == blas.Lower && r < c && c < m.N {
+		return 0
+	}
+	if m.Uplo == blas.Upper && r > c {
+		return 0
+	}
+	return m.Data[r*m.Stride+c]
+}
+
+// atOK is at, but always returns the actual stored value and
+// a boolean indicating whether it is a valid element.
+func (m rowMajorTriangular) atOK(r, c int) (v float64, ok bool) {
+	ok = true
+	if m.Diag == blas.Unit && r == c {
+		ok = true
+	}
+	if m.Uplo == blas.Lower && r < c && c < m.N {
+		ok = false
+	}
+	if m.Uplo == blas.Upper && r > c {
+		ok = false
+	}
+	return m.Data[r*m.Stride+c], ok
+}
+func (m rowMajorTriangular) uplo() blas.Uplo { return m.Uplo }
+func (m rowMajorTriangular) diag() blas.Diag { return m.Diag }
+
+type colMajorTriangular blas64.Triangular
+
+func (m colMajorTriangular) n() int { return m.N }
+func (m colMajorTriangular) at(r, c int) float64 {
+	if m.Diag == blas.Unit && r == c {
+		return 1
+	}
+	if m.Uplo == blas.Lower && r < c {
+		return 0
+	}
+	if m.Uplo == blas.Upper && r > c && r < m.N {
+		return 0
+	}
+	return m.Data[r+c*m.Stride]
+}
+
+// atOK is at, but always returns the actual stored value and
+// a boolean indicating whether it is a valid element.
+func (m colMajorTriangular) atOK(r, c int) (v float64, ok bool) {
+	ok = true
+	if m.Diag == blas.Unit && r == c {
+		ok = true
+	}
+	if m.Uplo == blas.Lower && r < c {
+		ok = false
+	}
+	if m.Uplo == blas.Upper && r > c && r < m.N {
+		ok = false
+	}
+	return m.Data[r+c*m.Stride], ok
+}
+func (m colMajorTriangular) uplo() blas.Uplo { return m.Uplo }
+func (m colMajorTriangular) diag() blas.Diag { return m.Diag }
+
+func equalTriangular(a, b triangular) bool {
+	an := a.n()
+	bn := b.n()
+	if an != bn {
+		return false
+	}
+	for i := 0; i < an; i++ {
+		for j := 0; j < an; j++ {
+			if a.at(i, j) != b.at(i, j) || math.IsNaN(a.at(i, j)) != math.IsNaN(b.at(i, j)) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+var triangularTests = []blas64.Triangular{
+	{N: 3, Stride: 3, Data: []float64{
+		1, 2, 3,
+		4, 5, 6,
+		7, 8, 9,
+	}},
+	{N: 3, Stride: 5, Data: []float64{
+		1, 2, 3, 0, 0,
+		4, 5, 6, 0, 0,
+		7, 8, 9, 0, 0,
+	}},
+}
+
+func TestConvertTriangular(t *testing.T) {
+	for _, test := range triangularTests {
+		for _, uplo := range []blas.Uplo{blas.Upper, blas.Lower, blas.All} {
+			for _, diag := range []blas.Diag{blas.Unit, blas.NonUnit} {
+				test.Uplo = uplo
+				test.Diag = diag
+				colmajor := NewColMajorTriangularFrom(test)
+				if !equalTriangular(colMajorTriangular(colmajor), rowMajorTriangular(test)) {
+					t.Errorf("unexpected result for row major to col major conversion:\n\tgot: %+v\n\tfrom:%+v",
+						colmajor, test)
+				}
+				rowmajor := NewRowMajorTriangularFrom(colmajor)
+				if !equalTriangular(rowMajorTriangular(rowmajor), rowMajorTriangular(test)) {
+					t.Errorf("unexpected result for row major to col major conversion:\n\tgot: %+v\n\twant:%+v",
+						rowmajor, test)
+				}
+			}
+		}
+	}
+}
+
+func TestCopyTriangularRowMajor(t *testing.T) {
+	for _, test := range triangularTests {
+		for _, uplo := range []blas.Uplo{blas.Upper, blas.Lower, blas.All} {
+			for _, diag := range []blas.Diag{blas.Unit, blas.NonUnit} {
+				src := test
+				src.Uplo = uplo
+				src.Diag = diag
+				for stride := src.N; stride <= src.Stride+1; stride++ {
+					dst := blas64.Triangular{
+						N:      src.N,
+						Stride: stride,
+						Data:   make([]float64, src.N*stride),
+						Uplo:   src.Uplo,
+						Diag:   src.Diag,
+					}
+					for i := range dst.Data {
+						dst.Data[i] = math.NaN()
+					}
+					CopyTriangularRowMajor(dst, src)
+					if !equalTriangular(rowMajorTriangular(dst), rowMajorTriangular(src)) {
+						t.Errorf("unexpected result for row major copy:\n\tgot: %+v\n\tfrom:%+v",
+							dst, src)
+					}
+					// We are abusing the indexing to see outside the real data.
+					for i := 0; i < dst.N; i++ {
+						for j := dst.N; j < dst.Stride; j++ {
+							if !math.IsNaN(rowMajorTriangular(dst).at(i, j)) {
+								t.Errorf("unexpected result for row major copy value overwritten at (%d,%d):\n\tgot: %+v\n\tfrom:%+v",
+									i, j, dst, src)
+							}
+						}
+					}
+
+					// Now check the invalid triangle for overwrites.
+					for i := 0; i < dst.N; i++ {
+						for j := 0; j < dst.N; j++ {
+							v, ok := rowMajorTriangular(dst).atOK(i, j)
+							if !ok && !math.IsNaN(v) {
+								t.Errorf("unexpected result for row major copy value overwritten at (%d,%d):\n\tgot: %+v\n\tfrom:%+v",
+									i, j, dst, src)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestCopyTriangularColMajor(t *testing.T) {
+	for _, test := range triangularTests {
+		for _, uplo := range []blas.Uplo{blas.Upper, blas.Lower, blas.All} {
+			for _, diag := range []blas.Diag{blas.Unit, blas.NonUnit} {
+				test.Uplo = uplo
+				test.Diag = diag
+				src := NewColMajorTriangularFrom(test)
+				for stride := src.N; stride <= src.Stride+1; stride++ {
+					dst := Triangular{
+						N:      src.N,
+						Stride: stride,
+						Data:   make([]float64, src.N*stride),
+						Uplo:   src.Uplo,
+						Diag:   src.Diag,
+					}
+					for i := range dst.Data {
+						dst.Data[i] = math.NaN()
+					}
+					CopyTriangularColMajor(dst, src)
+					if !equalTriangular(colMajorTriangular(dst), colMajorTriangular(src)) {
+						t.Errorf("unexpected result for col major copy:\n\tgot: %+v\n\tfrom:%+v",
+							dst, src)
+					}
+					// We are abusing the indexing to see outside the real data.
+					for i := dst.N; i < dst.Stride; i++ {
+						for j := 0; j < dst.N; j++ {
+							if !math.IsNaN(colMajorTriangular(dst).at(i, j)) {
+								t.Errorf("unexpected result for row major copy value overwritten at (%d,%d):\n\tgot: %+v\n\tfrom:%+v",
+									i, j, dst, src)
+							}
+						}
+					}
+
+					// Now check the invalid triangle for overwrites.
+					for i := 0; i < dst.N; i++ {
+						for j := 0; j < dst.N; j++ {
+							v, ok := colMajorTriangular(dst).atOK(i, j)
+							if !ok && !math.IsNaN(v) {
+								t.Errorf("unexpected result for row major copy value overwritten at (%d,%d):\n\tgot: %+v\n\tfrom:%+v",
+									i, j, dst, src)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is intended to be used in conjunction with the gc cgo fortran patch to aid LAPACK porting, but could in the longer term be made public elsewhere after being made more friendly.

@btracey Please take a look.
