### PR TITLE
Benchmarks for dbdsqr

### DIFF
--- a/cgo/lapack_bench_test.go
+++ b/cgo/lapack_bench_test.go
@@ -1,0 +1,35 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cgo
+
+import (
+	"testing"
+
+	"github.com/gonum/lapack/testlapack"
+)
+
+func BenchmarkDbdsqr100x100(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 100, 100, 0, false)
+}
+
+func BenchmarkDbdsqr200x200(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 200, 200, 0, false)
+}
+
+func BenchmarkDbdsqr300x300(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 300, 300, 0, false)
+}
+
+func BenchmarkDbdsqrWithVT100x100(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 100, 100, 0, true)
+}
+
+func BenchmarkDbdsqrWithVT200x200(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 200, 200, 0, true)
+}
+
+func BenchmarkDbdsqrWithVT300x300(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 300, 300, 0, true)
+}

--- a/cgo/lapack_bench_test.go
+++ b/cgo/lapack_bench_test.go
@@ -10,26 +10,32 @@ import (
 	"github.com/gonum/lapack/testlapack"
 )
 
+func BenchmarkDbdsqr10x10(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 10, 10, 0, false)
+}
+
+func BenchmarkDbdsqr50x50(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 50, 50, 0, false)
+}
 func BenchmarkDbdsqr100x100(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 100, 100, 0, false)
 }
-
 func BenchmarkDbdsqr200x200(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 200, 200, 0, false)
 }
-
-func BenchmarkDbdsqr300x300(b *testing.B) {
-	testlapack.DbdsqrBench(b, impl, 300, 300, 0, false)
+func BenchmarkDbdsqr1000x1000(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 1000, 1000, 0, false)
 }
 
+func BenchmarkDbdsqrWithVT50x50(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 50, 50, 0, true)
+}
 func BenchmarkDbdsqrWithVT100x100(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 100, 100, 0, true)
 }
-
 func BenchmarkDbdsqrWithVT200x200(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 200, 200, 0, true)
 }
-
-func BenchmarkDbdsqrWithVT300x300(b *testing.B) {
-	testlapack.DbdsqrBench(b, impl, 300, 300, 0, true)
+func BenchmarkDbdsqrWithVT1000x1000(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 1000, 1000, 0, true)
 }

--- a/cgo/lapack_bench_test.go
+++ b/cgo/lapack_bench_test.go
@@ -17,25 +17,35 @@ func BenchmarkDbdsqr10x10(b *testing.B) {
 func BenchmarkDbdsqr50x50(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 50, 50, 0, false)
 }
+
 func BenchmarkDbdsqr100x100(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 100, 100, 0, false)
 }
+
 func BenchmarkDbdsqr200x200(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 200, 200, 0, false)
 }
+
 func BenchmarkDbdsqr1000x1000(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 1000, 1000, 0, false)
+}
+
+func BenchmarkDbdsqrWithVT10x10(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 10, 10, 0, true)
 }
 
 func BenchmarkDbdsqrWithVT50x50(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 50, 50, 0, true)
 }
+
 func BenchmarkDbdsqrWithVT100x100(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 100, 100, 0, true)
 }
+
 func BenchmarkDbdsqrWithVT200x200(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 200, 200, 0, true)
 }
+
 func BenchmarkDbdsqrWithVT1000x1000(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 1000, 1000, 0, true)
 }

--- a/cgo/lapack_bench_test.go
+++ b/cgo/lapack_bench_test.go
@@ -1,4 +1,4 @@
-// Copyright ©2015 The gonum Authors. All rights reserved.
+// Copyright ©2016 The gonum Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/native/lapack_bench_test.go
+++ b/native/lapack_bench_test.go
@@ -1,0 +1,35 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package native
+
+import (
+	"testing"
+
+	"github.com/gonum/lapack/testlapack"
+)
+
+func BenchmarkDbdsqr100x100(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 100, 100, 0, false)
+}
+
+func BenchmarkDbdsqr200x200(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 200, 200, 0, false)
+}
+
+func BenchmarkDbdsqr300x300(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 300, 300, 0, false)
+}
+
+func BenchmarkDbdsqrWithVT100x100(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 100, 100, 0, true)
+}
+
+func BenchmarkDbdsqrWithVT200x200(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 200, 200, 0, true)
+}
+
+func BenchmarkDbdsqrWithVT300x300(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 300, 300, 0, true)
+}

--- a/native/lapack_bench_test.go
+++ b/native/lapack_bench_test.go
@@ -10,26 +10,32 @@ import (
 	"github.com/gonum/lapack/testlapack"
 )
 
+func BenchmarkDbdsqr10x10(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 10, 10, 0, false)
+}
+
+func BenchmarkDbdsqr50x50(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 50, 50, 0, false)
+}
 func BenchmarkDbdsqr100x100(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 100, 100, 0, false)
 }
-
 func BenchmarkDbdsqr200x200(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 200, 200, 0, false)
 }
-
-func BenchmarkDbdsqr300x300(b *testing.B) {
-	testlapack.DbdsqrBench(b, impl, 300, 300, 0, false)
+func BenchmarkDbdsqr1000x1000(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 1000, 1000, 0, false)
 }
 
+func BenchmarkDbdsqrWithVT50x50(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 50, 50, 0, true)
+}
 func BenchmarkDbdsqrWithVT100x100(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 100, 100, 0, true)
 }
-
 func BenchmarkDbdsqrWithVT200x200(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 200, 200, 0, true)
 }
-
-func BenchmarkDbdsqrWithVT300x300(b *testing.B) {
-	testlapack.DbdsqrBench(b, impl, 300, 300, 0, true)
+func BenchmarkDbdsqrWithVT1000x1000(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 1000, 1000, 0, true)
 }

--- a/native/lapack_bench_test.go
+++ b/native/lapack_bench_test.go
@@ -17,25 +17,35 @@ func BenchmarkDbdsqr10x10(b *testing.B) {
 func BenchmarkDbdsqr50x50(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 50, 50, 0, false)
 }
+
 func BenchmarkDbdsqr100x100(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 100, 100, 0, false)
 }
+
 func BenchmarkDbdsqr200x200(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 200, 200, 0, false)
 }
+
 func BenchmarkDbdsqr1000x1000(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 1000, 1000, 0, false)
+}
+
+func BenchmarkDbdsqrWithVT10x10(b *testing.B) {
+	testlapack.DbdsqrBench(b, impl, 10, 10, 0, true)
 }
 
 func BenchmarkDbdsqrWithVT50x50(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 50, 50, 0, true)
 }
+
 func BenchmarkDbdsqrWithVT100x100(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 100, 100, 0, true)
 }
+
 func BenchmarkDbdsqrWithVT200x200(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 200, 200, 0, true)
 }
+
 func BenchmarkDbdsqrWithVT1000x1000(b *testing.B) {
 	testlapack.DbdsqrBench(b, impl, 1000, 1000, 0, true)
 }

--- a/native/lapack_bench_test.go
+++ b/native/lapack_bench_test.go
@@ -1,4 +1,4 @@
-// Copyright ©2015 The gonum Authors. All rights reserved.
+// Copyright ©2016 The gonum Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/testlapack/dbdsqrbench.go
+++ b/testlapack/dbdsqrbench.go
@@ -1,0 +1,77 @@
+// Copyright ©2015 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/gonum/blas"
+)
+
+type DbdsqrerDgebrder interface {
+	Dbdsqrer
+	Dgebrder
+}
+
+func DbdsqrBench(b *testing.B, impl DbdsqrerDgebrder, m, n, lda int, useVT bool) {
+	// Construct a random bidiagonal matrix by applying Dgebrd on a random matrix.
+	// The benchmarking section of netlib, found at http://www.netlib.org/lapack/lug/node71.html
+	// indicates that benchmarks are typically done on random matricies that are
+	// transformed to produce desired properties (symmetry, diagonalization, etc.).
+
+	if lda == 0 {
+		lda = n
+	}
+
+	uplo := blas.Upper
+	if m < n {
+		uplo = blas.Lower
+	}
+
+	minmn := min(m, n)
+	a := make([]float64, m*lda)
+	d := make([]float64, minmn)
+	e := make([]float64, minmn-1)
+	tauP := make([]float64, minmn)
+	tauQ := make([]float64, minmn)
+
+	work := make([]float64, 1)
+
+	impl.Dgebrd(m, n, a, lda, d, e, tauP, tauQ, work, -1)
+	work = make([]float64, int(work[0]))
+	lwork := len(work)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+
+		// TODO(jonlawlor): When useVT is false, this initialization is a large
+		// portion of the benchmark time.  Because the number of iterations in a
+		// benchmark is inversely proportional to the time of a single iteration,
+		// this causes a large delay, because Dbdsqr is so fast, and the initialization
+		// time is ignored.  Maybe there is a way to amortize the cost of constructing
+		//  a random bidirectional matrix?
+		for i := range a {
+			a[i] = rand.NormFloat64()
+		}
+
+		impl.Dgebrd(m, n, a, lda, d, e, tauQ, tauP, work, lwork)
+		if useVT {
+			// Path might be used by dgesvd.
+			pt := make([]float64, n*n)
+			ldpt := n
+			for i := 0; i < n; i++ {
+				pt[i*ldpt+i] = 1
+			}
+
+			b.StartTimer()
+			impl.Dbdsqr(uplo, minmn, minmn, 0, 0, d, e, pt, minmn, nil, 0, nil, 0, work)
+			continue
+		}
+		b.StartTimer()
+		impl.Dbdsqr(uplo, minmn, 0, 0, 0, d, e, nil, 0, nil, 0, nil, 0, work)
+
+	}
+}

--- a/testlapack/dbdsqrbench.go
+++ b/testlapack/dbdsqrbench.go
@@ -21,7 +21,7 @@ func DbdsqrBench(b *testing.B, impl DbdsqrerDgebrder, m, n, lda int, useVT bool)
 	// The benchmarking section of netlib, found at http://www.netlib.org/lapack/lug/node71.html
 	// indicates that benchmarks are typically done on random matricies that are
 	// transformed to produce desired properties (symmetry, diagonalization, etc.).
-	rand.Seed(0)
+	rand.Seed(1)
 
 	if lda == 0 {
 		lda = n

--- a/testlapack/dbdsqrbench.go
+++ b/testlapack/dbdsqrbench.go
@@ -13,7 +13,7 @@ import (
 
 type DbdsqrerDgebrder interface {
 	Dbdsqrer
-	Dgebrder
+	Dgebrd(m, n int, a []float64, lda int, d, e, tauQ, tauP, work []float64, lwork int)
 }
 
 func DbdsqrBench(b *testing.B, impl DbdsqrerDgebrder, m, n, lda int, useVT bool) {

--- a/testlapack/dbdsqrbench.go
+++ b/testlapack/dbdsqrbench.go
@@ -1,4 +1,4 @@
-// Copyright ©2015 The gonum Authors. All rights reserved.
+// Copyright ©2016 The gonum Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
This is my first stab at benchmarks for dbdsqr.  I construct a random
bidiagonal matrix using dgebrd, and then optionally check the
performance when VT is used.  I don't have a sense for what typical
matrix sizes should be, so I picked some of the ones from the tests.
I'm also not sure how useful the additional outputs VT, etc. are, so I
might be heading in the wrong direction here.

PTAL @btracey @kortschak - this is a prerequisite for working on 
dbdsqr for #88 
