### PR TITLE
{cgo,native}: fix matrix typography

### DIFF
--- a/cgo/lapack.go
+++ b/cgo/lapack.go
@@ -260,18 +260,18 @@ func (impl Implementation) Dbdsqr(uplo blas.Uplo, n, ncvt, nru, ncc int, d, e, v
 //  G_i = I - tauP[i] * u_i * u_i^T
 //
 // As an example, on exit the entries of A when m = 6, and n = 5
-//  [d   e   u1  u1  u1]
-//  [v1  d   e   u2  u2]
-//  [v1  v2  d   e   u3]
-//  [v1  v2  v3  d   e ]
-//  [v1  v2  v3  v4  d ]
+//  [ d   e  u1  u1  u1]
+//  [v1   d   e  u2  u2]
+//  [v1  v2   d   e  u3]
+//  [v1  v2  v3   d   e]
+//  [v1  v2  v3  v4   d]
 //  [v1  v2  v3  v4  v5]
 // and when m = 5, n = 6
-//  [d   u1  u1  u1  u1  u1]
-//  [e   d   u2  u2  u2  u2]
-//  [v1  e   d   u3  u3  u3]
-//  [v1  v2  e   d   u4  u4]
-//  [v1  v2  v3  e   d   u5]
+//  [ d  u1  u1  u1  u1  u1]
+//  [ e   d  u2  u2  u2  u2]
+//  [v1   e   d  u3  u3  u3]
+//  [v1  v2   e   d  u4  u4]
+//  [v1  v2  v3   e   d  u5]
 //
 // d, tauQ, and tauP must all have length at least min(m,n), and e must have
 // length min(m,n) - 1.

--- a/cgo/lapack.go
+++ b/cgo/lapack.go
@@ -260,18 +260,18 @@ func (impl Implementation) Dbdsqr(uplo blas.Uplo, n, ncvt, nru, ncc int, d, e, v
 //  G_i = I - tauP[i] * u_i * u_i^T
 //
 // As an example, on exit the entries of A when m = 6, and n = 5
-//  (  d   e   u1  u1  u1 )
-//  (  v1  d   e   u2  u2 )
-//  (  v1  v2  d   e   u3 )
-//  (  v1  v2  v3  d   e  )
-//  (  v1  v2  v3  v4  d  )
-//  (  v1  v2  v3  v4  v5 )
+//  [d   e   u1  u1  u1]
+//  [v1  d   e   u2  u2]
+//  [v1  v2  d   e   u3]
+//  [v1  v2  v3  d   e ]
+//  [v1  v2  v3  v4  d ]
+//  [v1  v2  v3  v4  v5]
 // and when m = 5, n = 6
-//  (  d   u1  u1  u1  u1  u1 )
-//  (  e   d   u2  u2  u2  u2 )
-//  (  v1  e   d   u3  u3  u3 )
-//  (  v1  v2  e   d   u4  u4 )
-//  (  v1  v2  v3  e   d   u5 )
+//  [d   u1  u1  u1  u1  u1]
+//  [e   d   u2  u2  u2  u2]
+//  [v1  e   d   u3  u3  u3]
+//  [v1  v2  e   d   u4  u4]
+//  [v1  v2  v3  e   d   u5]
 //
 // d, tauQ, and tauP must all have length at least min(m,n), and e must have
 // length min(m,n) - 1.

--- a/native/dgebrd.go
+++ b/native/dgebrd.go
@@ -26,18 +26,18 @@ import (
 //  G_i = I - tauP[i] * u_i * u_i^T
 //
 // As an example, on exit the entries of A when m = 6, and n = 5
-//  (  d   e   u1  u1  u1 )
-//  (  v1  d   e   u2  u2 )
-//  (  v1  v2  d   e   u3 )
-//  (  v1  v2  v3  d   e  )
-//  (  v1  v2  v3  v4  d  )
-//  (  v1  v2  v3  v4  v5 )
+//  [d   e   u1  u1  u1]
+//  [v1  d   e   u2  u2]
+//  [v1  v2  d   e   u3]
+//  [v1  v2  v3  d   e ]
+//  [v1  v2  v3  v4  d ]
+//  [v1  v2  v3  v4  v5]
 // and when m = 5, n = 6
-//  (  d   u1  u1  u1  u1  u1 )
-//  (  e   d   u2  u2  u2  u2 )
-//  (  v1  e   d   u3  u3  u3 )
-//  (  v1  v2  e   d   u4  u4 )
-//  (  v1  v2  v3  e   d   u5 )
+//  [d   u1  u1  u1  u1  u1]
+//  [e   d   u2  u2  u2  u2]
+//  [v1  e   d   u3  u3  u3]
+//  [v1  v2  e   d   u4  u4]
+//  [v1  v2  v3  e   d   u5]
 //
 // d, tauQ, and tauP must all have length at least min(m,n), and e must have
 // length min(m,n) - 1.

--- a/native/dgebrd.go
+++ b/native/dgebrd.go
@@ -26,18 +26,18 @@ import (
 //  G_i = I - tauP[i] * u_i * u_i^T
 //
 // As an example, on exit the entries of A when m = 6, and n = 5
-//  [d   e   u1  u1  u1]
-//  [v1  d   e   u2  u2]
-//  [v1  v2  d   e   u3]
-//  [v1  v2  v3  d   e ]
-//  [v1  v2  v3  v4  d ]
+//  [ d   e  u1  u1  u1]
+//  [v1   d   e  u2  u2]
+//  [v1  v2   d   e  u3]
+//  [v1  v2  v3   d   e]
+//  [v1  v2  v3  v4   d]
 //  [v1  v2  v3  v4  v5]
 // and when m = 5, n = 6
-//  [d   u1  u1  u1  u1  u1]
-//  [e   d   u2  u2  u2  u2]
-//  [v1  e   d   u3  u3  u3]
-//  [v1  v2  e   d   u4  u4]
-//  [v1  v2  v3  e   d   u5]
+//  [ d  u1  u1  u1  u1  u1]
+//  [ e   d  u2  u2  u2  u2]
+//  [v1   e   d  u3  u3  u3]
+//  [v1  v2   e   d  u4  u4]
+//  [v1  v2  v3   e   d  u5]
 //
 // d, tauQ, and tauP must all have length at least min(m,n), and e must have
 // length min(m,n) - 1.

--- a/native/dlabrd.go
+++ b/native/dlabrd.go
@@ -29,18 +29,18 @@ import (
 //  G_i = I - tauP[i] * u_i * u_i^T
 //
 // As an example, on exit the entries of A when m = 6, n = 5, and nb = 2
-//  (  1   1   u1  u1  u1 )
-//  (  v1  1   1   u2  u2 )
-//  (  v1  v2  a   a   a  )
-//  (  v1  v2  a   a   a  )
-//  (  v1  v2  a   a   a  )
-//  (  v1  v2  a   a   a  )
+//  [1   1   u1  u1  u1]
+//  [v1  1   1   u2  u2]
+//  [v1  v2  a   a   a ]
+//  [v1  v2  a   a   a ]
+//  [v1  v2  a   a   a ]
+//  [v1  v2  a   a   a ]
 // and when m = 5, n = 6, and nb = 2
-//  (  1   u1  u1  u1  u1  u1 )
-//  (  1   1   u2  u2  u2  u2 )
-//  (  v1  1   a   a   a   a  )
-//  (  v1  v2  a   a   a   a  )
-//  (  v1  v2  a   a   a   a  )
+//  [1   u1  u1  u1  u1  u1]
+//  [1   1   u2  u2  u2  u2]
+//  [v1  1   a   a   a   a ]
+//  [v1  v2  a   a   a   a ]
+//  [v1  v2  a   a   a   a ]
 //
 // Dlabrd also returns the matrices X and Y which are used with U and V to
 // apply the transformation to the unreduced part of the matrix

--- a/native/dlabrd.go
+++ b/native/dlabrd.go
@@ -29,18 +29,18 @@ import (
 //  G_i = I - tauP[i] * u_i * u_i^T
 //
 // As an example, on exit the entries of A when m = 6, n = 5, and nb = 2
-//  [1   1   u1  u1  u1]
-//  [v1  1   1   u2  u2]
-//  [v1  v2  a   a   a ]
-//  [v1  v2  a   a   a ]
-//  [v1  v2  a   a   a ]
-//  [v1  v2  a   a   a ]
+//  [ 1   1  u1  u1  u1]
+//  [v1   1   1  u2  u2]
+//  [v1  v2   a   a   a]
+//  [v1  v2   a   a   a]
+//  [v1  v2   a   a   a]
+//  [v1  v2   a   a   a]
 // and when m = 5, n = 6, and nb = 2
-//  [1   u1  u1  u1  u1  u1]
-//  [1   1   u2  u2  u2  u2]
-//  [v1  1   a   a   a   a ]
-//  [v1  v2  a   a   a   a ]
-//  [v1  v2  a   a   a   a ]
+//  [ 1  u1  u1  u1  u1  u1]
+//  [ 1   1  u2  u2  u2  u2]
+//  [v1   1   a   a   a   a]
+//  [v1  v2   a   a   a   a]
+//  [v1  v2   a   a   a   a]
 //
 // Dlabrd also returns the matrices X and Y which are used with U and V to
 // apply the transformation to the unreduced part of the matrix

--- a/native/dlarfb.go
+++ b/native/dlarfb.go
@@ -24,25 +24,25 @@ import (
 // reflectors. In all cases the ones on the diagonal are implicitly represented.
 //
 // If direct == lapack.Forward and store == lapack.ColumnWise
-//  V = [ 1      ]
-//      [v1  1   ]
-//      [v1 v2  1]
-//      [v1 v2 v3]
-//      [v1 v2 v3]
+//  V = [ 1        ]
+//      [v1   1    ]
+//      [v1  v2   1]
+//      [v1  v2  v3]
+//      [v1  v2  v3]
 // If direct == lapack.Forward and store == lapack.RowWise
-//  V = [ 1 v1 v1 v1 v1]
-//      [    1 v2 v2 v2]
-//      [       1 v3 v3]
+//  V = [ 1  v1  v1  v1  v1]
+//      [     1  v2  v2  v2]
+//      [         1  v3  v3]
 // If direct == lapack.Backward and store == lapack.ColumnWise
-//  V = [v1 v2 v3]
-//      [v1 v2 v3]
-//      [ 1 v2 v3]
-//      [    1 v3]
-//      [       1]
+//  V = [v1  v2  v3]
+//      [v1  v2  v3]
+//      [ 1  v2  v3]
+//      [     1  v3]
+//      [         1]
 // If direct == lapack.Backward and store == lapack.RowWise
-//  V = [v1 v1  1      ]
-//      [v2 v2 v2  1   ]
-//      [v3 v3 v3 v3  1]
+//  V = [v1  v1   1        ]
+//      [v2  v2  v2   1    ]
+//      [v3  v3  v3  v3   1]
 // An elementary reflector can be explicitly constructed by extracting the
 // corresponding elements of v, placing a 1 where the diagonal would be, and
 // placing zeros in the remaining elements.

--- a/native/dlarfb.go
+++ b/native/dlarfb.go
@@ -24,25 +24,25 @@ import (
 // reflectors. In all cases the ones on the diagonal are implicitly represented.
 //
 // If direct == lapack.Forward and store == lapack.ColumnWise
-//  V = (  1       )
-//      ( v1  1    )
-//      ( v1 v2  1 )
-//      ( v1 v2 v3 )
-//      ( v1 v2 v3 )
+//  V = [ 1      ]
+//      [v1  1   ]
+//      [v1 v2  1]
+//      [v1 v2 v3]
+//      [v1 v2 v3]
 // If direct == lapack.Forward and store == lapack.RowWise
-//  V = (  1 v1 v1 v1 v1 )
-//      (     1 v2 v2 v2 )
-//      (        1 v3 v3 )
+//  V = [ 1 v1 v1 v1 v1]
+//      [    1 v2 v2 v2]
+//      [       1 v3 v3]
 // If direct == lapack.Backward and store == lapack.ColumnWise
-//  V = ( v1 v2 v3 )
-//      ( v1 v2 v3 )
-//      (  1 v2 v3 )
-//      (     1 v3 )
-//      (        1 )
+//  V = [v1 v2 v3]
+//      [v1 v2 v3]
+//      [ 1 v2 v3]
+//      [    1 v3]
+//      [       1]
 // If direct == lapack.Backward and store == lapack.RowWise
-//  V = ( v1 v1  1       )
-//      ( v2 v2 v2  1    )
-//      ( v3 v3 v3 v3  1 )
+//  V = [v1 v1  1      ]
+//      [v2 v2 v2  1   ]
+//      [v3 v3 v3 v3  1]
 // An elementary reflector can be explicitly constructed by extracting the
 // corresponding elements of v, placing a 1 where the diagonal would be, and
 // placing zeros in the remaining elements.

--- a/native/dlartg.go
+++ b/native/dlartg.go
@@ -7,7 +7,7 @@ package native
 import "math"
 
 // Dlartg generates a plane rotation so that
-//  [cs  sn] * [f] = [r]
+//  [ cs sn] * [f] = [r]
 //  [-sn cs]   [g] = [0]
 // This is a more accurate version of BLAS drotg, with the other differences that
 // if g = 0, then cs = 1 and sn = 0, and if f = 0 and g != 0, then cs = 0 and sn = 1.

--- a/native/dlatrd.go
+++ b/native/dlatrd.go
@@ -23,18 +23,18 @@ import (
 // set to 1, and the remaining elements contain the data to construct Q.
 //
 // If uplo == blas.Upper, with n = 5 and nb = 2 on exit a is
-//  [a  a  a v4 v5]
-//  [   a  a v4 v5]
-//  [      a  1 v5]
-//  [         d  1]
-//  [            d]
+//  [ a   a   a  v4  v5]
+//  [     a   a  v4  v5]
+//  [         a   1  v5]
+//  [             d   1]
+//  [                 d]
 //
 // If uplo == blas.Lower, with n = 5 and nb = 2, on exit a is
-//  [d            ]
-//  [1  d         ]
-//  [v1 1  a      ]
-//  [v1 v2 a  a   ]
-//  [v1 v2 a  a  a]
+//  [ d                ]
+//  [ 1   d            ]
+//  [v1   1   a        ]
+//  [v1  v2   a   a    ]
+//  [v1  v2   a   a   a]
 //
 // e contains the superdiagonal elements of the reduced matrix. If uplo == blas.Upper,
 // e[n-nb:n-1] contains the last nb columns of the reduced matrix, while if

--- a/native/dsytd2.go
+++ b/native/dsytd2.go
@@ -33,19 +33,19 @@ import (
 //
 // If uplo == blas.Upper, v[0:i-1] is stored in A[0:i-1,i+1], v[i] = 1, and
 // v[i+1:] = 0. The elements of a are
-//  [d  e  v2 v3 v4]
-//  [   d  e  v3 v4]
-//  [      d  e  v4]
-//  [         d  e ]
-//  [            d ]
+//  [ d   e  v2  v3  v4]
+//  [     d   e  v3  v4]
+//  [         d   e  v4]
+//  [             d   e]
+//  [                 d]
 // If uplo == blas.Lower, v[0:i+1] = 0, v[i+1] = 1, and v[i+2:] is stored in
 // A[i+2:n,i].
 // The elements of a are
-//  [d            ]
-//  [e  d         ]
-//  [v1 e  d      ]
-//  [v1 v2 e  d   ]
-//  [v1 v2 v3 e  d]
+//  [ d                ]
+//  [ e   d            ]
+//  [v1   e   d        ]
+//  [v1  v2   e   d    ]
+//  [v1  v2  v3   e   d]
 func (impl Implementation) Dsytd2(uplo blas.Uplo, n int, a []float64, lda int, d, e, tau []float64) {
 	checkMatrix(n, n, a, lda)
 	if len(d) < n {


### PR DESCRIPTION
Use square brackets throughout and use an (almost) uniform matrix cell layout. All matrix cells are right justified and cells are the width of the largest element (negative signs treated according to taste here). Large matrices have 2 space gutter between elements and 2x2 matrices or smaller have 1 space gutter.

Fixes #97.

@btracey Please take a look.