### PR TITLE
native: change loop condition for blocked part of Dgehrd

### DIFF
--- a/native/dgehrd.go
+++ b/native/dgehrd.go
@@ -137,7 +137,7 @@ func (impl Implementation) Dgehrd(n, ilo, ihi int, a []float64, lda int, tau, wo
 		// Use blocked code.
 		bi := blas64.Implementation()
 		iwt := n * nb // Size of the matrix Y and index where the matrix T starts in work.
-		for i = ilo; i < ihi-nx; i += nb {
+		for i = ilo; i < ihi-nb; i += nb {
 			ib := min(nb, ihi-i)
 
 			// Reduce columns [i:i+ib] to Hessenberg form, returning the

--- a/native/ilaenv.go
+++ b/native/ilaenv.go
@@ -6,10 +6,13 @@ package native
 
 // Ilaenv returns algorithm tuning parameters for the algorithm given by the
 // input string. ispec specifies the parameter to return:
-//  1: The optimal block size for a blocked algorithm.
-//  2: The minimum block size for a blocked algorithm.
-//  3: The block size of unprocessed data at which a blocked algorithm should
-//     crossover to an unblocked version.
+//  1: The optimal block size. If this value is 1, an unblocked algorithm will
+//     give the best performance.
+//  2: The minimum block size for which the block routine should be used. If the
+//     usable block size is less than this value, an unblocked routine should be
+//     used.
+//  3: The crossover point between a blocked and unblocked algorithm. In a block
+//     routine, for N less than this value, an unblocked routine should be used.
 //  4: The number of shifts.
 //  5: The minimum column dimension for blocking to be used.
 //  6: The crossover point for SVD (to use QR factorization or not).


### PR DESCRIPTION
I brought this up in #134. I feel there is a confusion about what the value 3 passed as `ispec` parameter to `Ilaenv` means.

netlib lapack code uses the returned crossover point as the size of the unprocessed block at which to switch from blocked to unblocked code. Take as an example Dgehrd, n = 130, block size 32, and crossover 128. With these values the blocked code processes 32 columns, remaining size is less than crossover, and the rest is processed by unblocked code. This seems very strange, why not process all 4 blocks and the remaining two columns with unblocked?

The following would make more sense to me: if n is less than crossover, the matrix is small, so don't bother with the blocked code. Once the matrix is larger, as in the above example, there are enough blocks (4), so process them with blocked code and the rest with unblocked code.

I copied the respective docs formulation from Lapack but it does not shed much light on this. It refers to N which suggests it is a decision made based on the matrix size, not on the remaining unprocessed size.

In our native, @btracey also noticed this strangeness and fixed it somewhere to the more sensible option (e.g., in Dgebrd) but not everywhere (e.g., in Dsytrd). It is not as simple as replacing nx with nb, see Dsytrd.go:110.

Perhaps this is something to be asked at the Lapack forum?
