### PR TITLE
populate OpenBLAS cache, unset -ex in scripts

### DIFF
--- a/.travis/linux/ATLAS/install.sh
+++ b/.travis/linux/ATLAS/install.sh
@@ -15,4 +15,12 @@ pushd cgo/clapack
 go install -v -x
 popd
 
+# travis compiles commands in script and then executes in bash.  By adding
+# set -e we are changing the travis build script's behavior, and the set
+# -e lives on past the commands we are providing it.  Some of the travis
+# commands are supposed to exit with non zero status, but then continue
+# executing.  set -x makes the travis log files extremely verbose and
+# difficult to understand.
+# 
+# see travis-ci/travis-ci#5120
 set +ex

--- a/.travis/linux/ATLAS/install.sh
+++ b/.travis/linux/ATLAS/install.sh
@@ -14,3 +14,5 @@ go get github.com/gonum/matrix/mat64
 pushd cgo/clapack
 go install -v -x
 popd
+
+set +ex

--- a/.travis/linux/OpenBLAS/install.sh
+++ b/.travis/linux/OpenBLAS/install.sh
@@ -19,7 +19,6 @@ if [ -e ${CACHE_DIR}/last_commit_id ]; then
     fi
 fi
 
-# check if cache directory exists
 if [ ! -e ${CACHE_DIR}/last_commit_id ]; then
     if [ -d ${CACHE_DIR} ]; then
         # Travis automatically creates the cache directory if it does not exist,

--- a/.travis/linux/OpenBLAS/install.sh
+++ b/.travis/linux/OpenBLAS/install.sh
@@ -20,11 +20,8 @@ if [ -e ${CACHE_DIR}/last_commit_id ]; then
 fi
 
 if [ ! -e ${CACHE_DIR}/last_commit_id ]; then
-    if [ -d ${CACHE_DIR} ]; then
-        # Travis automatically creates the cache directory if it does not exist,
-        # so this is needed for initialization.
-        rm -rf ${CACHE_DIR}
-    fi
+    # Clear cache.
+    rm -rf ${CACHE_DIR}
 
     # cache generation
     echo "Building cache at $CACHE_DIR"

--- a/.travis/linux/OpenBLAS/install.sh
+++ b/.travis/linux/OpenBLAS/install.sh
@@ -63,4 +63,12 @@ pushd cgo/clapack
 go install -v -x
 popd
 
+# travis compiles commands in script and then executes in bash.  By adding
+# set -e we are changing the travis build script's behavior, and the set
+# -e lives on past the commands we are providing it.  Some of the travis
+# commands are supposed to exit with non zero status, but then continue
+# executing.  set -x makes the travis log files extremely verbose and
+# difficult to understand.
+# 
+# see travis-ci/travis-ci#5120
 set +ex

--- a/.travis/linux/OpenBLAS/install.sh
+++ b/.travis/linux/OpenBLAS/install.sh
@@ -29,9 +29,6 @@ if [ ! -e ${CACHE_DIR}/last_commit_id ]; then
     sudo git clone --depth=1 git://github.com/xianyi/OpenBLAS
 
     pushd OpenBLAS
-    echo OpenBLAS $(git rev-parse HEAD)
-    # write commit id to cache location
-    echo $(git rev-parse HEAD) > ${CACHE_DIR}/last_commit_id
     sudo make FC=gfortran &> /dev/null && sudo make PREFIX=${CACHE_DIR} install
     popd
 
@@ -41,6 +38,11 @@ if [ ! -e ${CACHE_DIR}/last_commit_id ]; then
     sudo mv Makefile.LINUX Makefile.in
     sudo BLLIB=${CACHE_DIR}/lib/libopenblas.a make alllib
     sudo mv lib/cblas_LINUX.a ${CACHE_DIR}/lib/libcblas.a
+    popd
+
+    # Record commit id used to generate cache.
+    pushd OpenBLAS
+    echo $(git rev-parse HEAD) > ${CACHE_DIR}/last_commit_id
     popd
 
 fi

--- a/.travis/linux/OpenBLAS/install.sh
+++ b/.travis/linux/OpenBLAS/install.sh
@@ -1,31 +1,58 @@
 set -ex
 
+CACHE_DIR=${TRAVIS_BUILD_DIR}/.travis/${BLAS_LIB}.cache
+
 # fetch fortran to build OpenBLAS
-sudo apt-get update -qq
-sudo apt-get install -qq gfortran
+sudo apt-get update -qq && sudo apt-get install -qq gfortran
 
-# fetch OpenBLAS
-pushd ~
-sudo git clone --depth=1 git://github.com/xianyi/OpenBLAS
+# check if cache exists
+if [ -e ${CACHE_DIR}/last_commit_id ]; then
+    echo "Cache $CACHE_DIR hit"
+    LAST_COMMIT="$(git ls-remote git://github.com/xianyi/OpenBLAS HEAD | grep -o '^\S*')"
+    CACHED_COMMIT="$(cat ${CACHE_DIR}/last_commit_id)"
+    # determine current OpenBLAS master commit id and compare
+    # with commit id in cache directory
+    if [ "$LAST_COMMIT" != "$CACHED_COMMIT" ]; then
+        echo "Cache Directory $CACHE_DIR has stale commit"
+        # if commit is different, delete the cache
+        rm -rf ${CACHE_DIR}
+    fi
+fi
 
-# make OpenBLAS
-pushd OpenBLAS
-echo OpenBLAS $(git rev-parse HEAD)
-sudo make FC=gfortran &> /dev/null
-sudo make PREFIX=/usr install
-popd
+# check if cache directory exists
+if [ ! -e ${CACHE_DIR}/last_commit_id ]; then
+    if [ -d ${CACHE_DIR} ]; then
+        # Travis automatically creates the cache directory if it does not exist,
+        # so this is needed for initialization.
+        rm -rf ${CACHE_DIR}
+    fi
 
-# fetch cblas reference lib
-curl http://www.netlib.org/blas/blast-forum/cblas.tgz | tar -zx
+    # cache generation
+    echo "Building cache at $CACHE_DIR"
+    mkdir ${CACHE_DIR}
+    sudo git clone --depth=1 git://github.com/xianyi/OpenBLAS
 
-# make and install cblas
-pushd CBLAS
-sudo mv Makefile.LINUX Makefile.in
-sudo BLLIB=/usr/lib/libopenblas.a make alllib
-sudo mv lib/cblas_LINUX.a /usr/lib/libcblas.a
-popd
-popd
+    pushd OpenBLAS
+    echo OpenBLAS $(git rev-parse HEAD)
+    # write commit id to cache location
+    echo $(git rev-parse HEAD) > ${CACHE_DIR}/last_commit_id
+    sudo make FC=gfortran &> /dev/null && sudo make PREFIX=${CACHE_DIR} install
+    popd
 
+    curl http://www.netlib.org/blas/blast-forum/cblas.tgz | tar -zx
+
+    pushd CBLAS
+    sudo mv Makefile.LINUX Makefile.in
+    sudo BLLIB=${CACHE_DIR}/lib/libopenblas.a make alllib
+    sudo mv lib/cblas_LINUX.a ${CACHE_DIR}/lib/libcblas.a
+    popd
+
+fi
+
+# copy the cache files into /usr
+sudo cp -r ${CACHE_DIR}/* /usr/
+
+# install gonum/blas against OpenBLAS
 # fetch and install gonum/blas and gonum/matrix
 export CGO_LDFLAGS="-L/usr/lib -lopenblas"
 go get github.com/gonum/blas
@@ -35,3 +62,5 @@ go get github.com/gonum/matrix/mat64
 pushd cgo/clapack
 go install -v -x
 popd
+
+set +ex

--- a/.travis/linux/gonum/install.sh
+++ b/.travis/linux/gonum/install.sh
@@ -4,4 +4,12 @@ set -ex
 go get github.com/gonum/blas
 go get github.com/gonum/matrix/mat64
 
+# travis compiles commands in script and then executes in bash.  By adding
+# set -e we are changing the travis build script's behavior, and the set
+# -e lives on past the commands we are providing it.  Some of the travis
+# commands are supposed to exit with non zero status, but then continue
+# executing.  set -x makes the travis log files extremely verbose and
+# difficult to understand.
+# 
+# see travis-ci/travis-ci#5120
 set +ex

--- a/.travis/linux/gonum/install.sh
+++ b/.travis/linux/gonum/install.sh
@@ -3,3 +3,5 @@ set -ex
 # fetch gonum/blas and gonum/matrix
 go get github.com/gonum/blas
 go get github.com/gonum/matrix/mat64
+
+set +ex


### PR DESCRIPTION
Same as gonum/blas#184 - use a prebuilt cache of the OpenBLAS libraries instead of recompiling every time.