### PR TITLE
native,testlapack: fix Dlaexc and its test

### DIFF
--- a/native/dlaexc.go
+++ b/native/dlaexc.go
@@ -111,7 +111,7 @@ func (impl Implementation) Dlaexc(wantq bool, n int, t []float64, ldt int, q []f
 	// Solve T11*X - X*T22 = scale*T12 for X.
 	var x [4]float64
 	const ldx = 2
-	scale, _, _ := impl.Dlasy2(false, false, -1, n1, n2, d[:], ldd, d[n1*ldd+n1:], ldd, d[n1+1:], ldd, x[:], ldx)
+	scale, _, _ := impl.Dlasy2(false, false, -1, n1, n2, d[:], ldd, d[n1*ldd+n1:], ldd, d[n1:], ldd, x[:], ldx)
 
 	// Swap the adjacent diagonal blocks.
 	switch {

--- a/native/dlaexc.go
+++ b/native/dlaexc.go
@@ -30,6 +30,8 @@ import (
 //
 // If ok is false, the transformed matrix T would be too far from Schur form.
 // The blocks are not swapped, and T and Q are not modified.
+//
+// Dlaexc is an internal routine. It is exported for testing purposes.
 func (impl Implementation) Dlaexc(wantq bool, n int, t []float64, ldt int, q []float64, ldq int, j1, n1, n2 int, work []float64) (ok bool) {
 	checkMatrix(n, n, t, ldt)
 	if wantq {

--- a/testlapack/general.go
+++ b/testlapack/general.go
@@ -838,3 +838,27 @@ func eye(n, stride int) blas64.General {
 	}
 	return ans
 }
+
+// extract2x2Block returns the elements of T at [0,0], [0,1], [1,0], and [1,1].
+func extract2x2Block(t []float64, ldt int) (a, b, c, d float64) {
+	return t[0], t[1], t[ldt], t[ldt+1]
+}
+
+// isSchurCanonical returns whether the 2×2 matrix [a b; c d] is in Schur
+// canonical form.
+func isSchurCanonical(a, b, c, d float64) bool {
+	return c == 0 || (a == d && math.Signbit(b) != math.Signbit(c))
+}
+
+// schurBlockEigenvalues returns the two eigenvalues of the 2×2 matrix [a b; c d]
+// that must be in Schur canonical form.
+func schurBlockEigenvalues(a, b, c, d float64) (ev1, ev2 complex128) {
+	if !isSchurCanonical(a, b, c, d) {
+		panic("block not in Schur canonical form")
+	}
+	if c == 0 {
+		return complex(a, 0), complex(d, 0)
+	}
+	im := math.Sqrt(-b * c)
+	return complex(a, im), complex(a, -im)
+}


### PR DESCRIPTION
I'm sorry. If only someone could elucidate what exactly I was thinking when I wrote the original ...

Such a wholly unremarkable off-by-one error. Why this went (almost) undetected: because of the error, the matrix d did not have zeros where it should, therefore Dlaexc returned with a false in the `> thresh` checks, and therefore the tests exited early `if !ok`. I did notice that Dlaexc returned sometimes with a false but I didn't notice that it was always except for the trivial or 1x1 cases. Therefore I mistakenly attributed it to floating point effects.

The tests are a different story. I noticed **something** is wrong with them after fixing the indexing error. I don't know what I was thinking there.

PTAL @kortschak @btracey 