### PR TITLE
native: change Dlahqr back to return single integer

### DIFF
--- a/native/dlahqr.go
+++ b/native/dlahqr.go
@@ -13,10 +13,9 @@ import (
 // Dlahqr computes the eigenvalues and Schur factorization of a block of an n×n
 // upper Hessenberg matrix H, using the double-shift/single-shift QR algorithm.
 //
-// h and ldh represent the matrix H. The contents of h on return depends on the
-// value of converged. Dlahqr works primarily with the Hessenberg submatrix
-// H[ilo:ihi+1,ilo:ihi+1], but applies transformations to all of H if wantt is
-// true. It is assumed that H[ihi+1:n,ihi+1:n] is already upper
+// h and ldh represent the matrix H. Dlahqr works primarily with the Hessenberg
+// submatrix H[ilo:ihi+1,ilo:ihi+1], but applies transformations to all of H if
+// wantt is true. It is assumed that H[ihi+1:n,ihi+1:n] is already upper
 // quasi-triangular, although this is not checked.
 //
 // It must hold that
@@ -25,7 +24,7 @@ import (
 //  H[ilo,ilo-1] == 0,  if ilo > 0,
 // otherwise Dlahqr will panic.
 //
-// wr[ilo:ihi+1] and wi[ilo:ihi+1] will contain, on return if converged is true,
+// If unconverged is zero, wr[ilo:ihi+1] and wi[ilo:ihi+1] will contain on return
 // the real and imaginary parts, respectively, of the computed eigenvalues ilo
 // to ihi. If two eigenvalues are computed as a complex conjugate pair, they are
 // stored in consecutive elements of wr and wi, say the i-th and (i+1)th, with
@@ -37,32 +36,37 @@ import (
 // wr and wi must have length n.
 //
 // z and ldz represent an n×n matrix Z. If wantz is true, the transformations
-// will be applied to the submatrix Z[iloz:ihiz+1,ilo:ihi+1]. If wantz is false,
-// z is not referenced. It must hold that
-//  0 <= iloz <= ilo; ihi <= ihiz < n.
-
-// converged indicates whether Dlahqr computed all the eigenvalues ilo to ihi in
-// a total of 30 iterations per eigenvalue. If converged is false, some
-// eigenvalues have not converged, and wr[index+1:ihi+1] and wi[index+1:ihi+1]
-// contain those eigenvalues which have been successfully computed.
+// will be applied to the submatrix Z[iloz:ihiz+1,ilo:ihi+1] and it must hold that
+//  0 <= iloz <= ilo, and ihi <= ihiz < n.
+// If wantz is false, z is not referenced.
 //
-// If converged is true and wantt is true, on return H[ilo:ihi+1,ilo:ihi+1] will
-// be overwritten by upper quasi-triangular full Schur form with any 2×2
-// diagonal blocks in standard form.
+// unconverged indicates whether Dlahqr computed all the eigenvalues ilo to ihi
+// in a total of 30 iterations per eigenvalue.
 //
-// If converged is true and wantt is false, the contents of h on return is
+// If unconverged is zero, all the eigenvalues ilo to ihi have been computed and
+// will be stored on return in wr[ilo:ihi+1] and wi[ilo:ihi+1].
+//
+// If unconverged is zero and wantt is true, H[ilo:ihi+1,ilo:ihi+1] will be
+// overwritten on return by upper quasi-triangular full Schur form with any
+// 2×2 diagonal blocks in standard form.
+//
+// If unconverged is zero and if wantt is false, the contents of h on return is
 // unspecified.
 //
-// If converged is false and wantt is false, on return, the remaining
-// unconverged eigenvalues are the eigenvalues of the upper Hessenberg matrix
-// H[ilo:index+1,ilo:index+1].
+// If unconverged is positive, some eigenvalues have not converged, and
+// wr[unconverged:ihi+1] and wi[unconverged:ihi+1] contain those eigenvalues
+// which have been successfully computed.
 //
-// If converged is false and wantt is true, then on return
+// If unconverged is positive and wantt is true, then on return
 //  (initial H)*U = U*(final H),   (*)
 // where U is an orthogonal matrix. The final H is upper Hessenberg and
-// H[index+1:ihi+1,index+1:ihi+1] is upper triangular.
+// H[unconverged:ihi+1,unconverged:ihi+1] is upper quasi-triangular.
 //
-// If converged is false and wantz is true, then on return
+// If unconverged is positive and wantt is false, on return the remaining
+// unconverged eigenvalues are the eigenvalues of the upper Hessenberg matrix
+// H[ilo:unconverged,ilo:unconverged].
+//
+// If unconverged is positive and wantz is true, then on return
 //  (final Z) = (initial Z)*U,
 // where U is the orthogonal matrix in (*) regardless of the value of wantt.
 //

--- a/native/dlahqr.go
+++ b/native/dlahqr.go
@@ -67,7 +67,7 @@ import (
 // where U is the orthogonal matrix in (*) regardless of the value of wantt.
 //
 // Dlahqr is an internal routine. It is exported for testing purposes.
-func (impl Implementation) Dlahqr(wantt, wantz bool, n, ilo, ihi int, h []float64, ldh int, wr, wi []float64, iloz, ihiz int, z []float64, ldz int) (index int, converged bool) {
+func (impl Implementation) Dlahqr(wantt, wantz bool, n, ilo, ihi int, h []float64, ldh int, wr, wi []float64, iloz, ihiz int, z []float64, ldz int) (unconverged int) {
 	checkMatrix(n, n, h, ldh)
 	switch {
 	case ilo < 0 || max(0, ihi) < ilo:
@@ -93,12 +93,12 @@ func (impl Implementation) Dlahqr(wantt, wantz bool, n, ilo, ihi int, h []float6
 
 	// Quick return if possible.
 	if n == 0 {
-		return 0, true
+		return 0
 	}
 	if ilo == ihi {
 		wr[ilo] = h[ilo*ldh+ilo]
 		wi[ilo] = 0
-		return 0, true
+		return 0
 	}
 
 	// Clear out the trash.
@@ -379,7 +379,7 @@ func (impl Implementation) Dlahqr(wantt, wantz bool, n, ilo, ihi int, h []float6
 		if converged == false {
 			// The QR iteration finished without splitting off a
 			// submatrix of order 1 or 2.
-			return i, false
+			return i + 1
 		}
 
 		if l == i {
@@ -415,5 +415,5 @@ func (impl Implementation) Dlahqr(wantt, wantz bool, n, ilo, ihi int, h []float6
 		// Return to start of the main loop with new value of i.
 		i = l - 1
 	}
-	return 0, true
+	return 0
 }

--- a/testlapack/dlahqr.go
+++ b/testlapack/dlahqr.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Dlahqrer interface {
-	Dlahqr(wantt, wantz bool, n, ilo, ihi int, h []float64, ldh int, wr, wi []float64, iloz, ihiz int, z []float64, ldz int) (int, bool)
+	Dlahqr(wantt, wantz bool, n, ilo, ihi int, h []float64, ldh int, wr, wi []float64, iloz, ihiz int, z []float64, ldz int) int
 }
 
 func DlahqrTest(t *testing.T, impl Dlahqrer) {
@@ -137,7 +137,7 @@ func testDlahqr(t *testing.T, impl Dlahqrer, wantt, wantz bool, n, ilo, ihi, ilo
 	wr := nanSlice(n)
 	wi := nanSlice(n)
 
-	idx, converged := impl.Dlahqr(wantt, wantz, n, ilo, ihi, h.Data, h.Stride, wr, wi, iloz, ihiz, z.Data, z.Stride)
+	unconverged := impl.Dlahqr(wantt, wantz, n, ilo, ihi, h.Data, h.Stride, wr, wi, iloz, ihiz, z.Data, z.Stride)
 
 	prefix := fmt.Sprintf("Case n=%v, ilo=%v, ihi=%v, iloz=%v, ihiz=%v, wantt=%v, wantz=%v, extra=%v", n, ilo, ihi, iloz, ihiz, wantt, wantz, extra)
 
@@ -168,8 +168,11 @@ func testDlahqr(t *testing.T, impl Dlahqrer, wantt, wantz bool, n, ilo, ihi, ilo
 	}
 
 	start := ilo // Index of the first computed eigenvalue.
-	if !converged {
-		start = idx + 1
+	if unconverged != 0 {
+		start = unconverged
+		if start == ihi+1 {
+			t.Logf("%v: no eigenvalue has converged", prefix)
+		}
 	}
 
 	// Check that wr and wi have not been modified outside [start:ihi+1].


### PR DESCRIPTION
If the returned integer is a 1-based size and not a 0-based index, we can use 0 to indicate success (i.e., all eigenvalues have converged) and thus the `converged bool` is not necessary.

Also polished the docs a little.

PTAL