### PR TITLE
native: add Dlaqr2

### DIFF
--- a/cgo/lapack.go
+++ b/cgo/lapack.go
@@ -577,18 +577,21 @@ func (impl Implementation) Dgeqrf(m, n int, a []float64, lda int, tau, work []fl
 //
 // Dgehrd is an internal routine. It is exported for testing purposes.
 func (impl Implementation) Dgehrd(n, ilo, ihi int, a []float64, lda int, tau, work []float64, lwork int) {
-	checkMatrix(n, n, a, lda)
 	switch {
 	case ilo < 0 || max(0, n-1) < ilo:
 		panic(badIlo)
 	case ihi < min(ilo, n-1) || n <= ihi:
 		panic(badIhi)
-	case len(work) < lwork:
-		panic(shortWork)
 	case lwork < max(1, n) && lwork != -1:
 		panic(badWork)
-	case n > 0 && len(tau) != n-1 && lwork != -1:
-		panic(badTau)
+	case len(work) < lwork:
+		panic(shortWork)
+	}
+	if lwork != -1 {
+		checkMatrix(n, n, a, lda)
+		if len(tau) != n-1 && n > 0 {
+			panic(badTau)
+		}
 	}
 	clapack.Dgehrd(n, ilo+1, ihi+1, a, lda, tau, work, lwork)
 }
@@ -1105,8 +1108,6 @@ func (impl Implementation) Dormhr(side blas.Side, trans blas.Transpose, m, n, il
 	default:
 		panic(badSide)
 	}
-	checkMatrix(m, n, c, ldc)
-	checkMatrix(nq, nq, a, lda)
 	switch {
 	case trans != blas.NoTrans && trans != blas.Trans:
 		panic(badTrans)
@@ -1114,12 +1115,17 @@ func (impl Implementation) Dormhr(side blas.Side, trans blas.Transpose, m, n, il
 		panic(badIlo)
 	case ihi < min(ilo, nq-1) || nq <= ihi:
 		panic(badIhi)
-	case nq > 0 && len(tau) != nq-1 && lwork != -1:
-		panic(badTau)
 	case lwork < max(1, nw) && lwork != -1:
 		panic(badWork)
 	case len(work) < max(1, lwork):
 		panic(shortWork)
+	}
+	if lwork != -1 {
+		checkMatrix(m, n, c, ldc)
+		checkMatrix(nq, nq, a, lda)
+		if len(tau) != nq-1 && nq > 0 {
+			panic(badTau)
+		}
 	}
 	clapack.Dormhr(side, trans, m, n, ilo+1, ihi+1, a, lda, tau, c, ldc, work, lwork)
 }

--- a/native/dgehrd.go
+++ b/native/dgehrd.go
@@ -66,18 +66,21 @@ import (
 //
 // Dgehrd is an internal routine. It is exported for testing purposes.
 func (impl Implementation) Dgehrd(n, ilo, ihi int, a []float64, lda int, tau, work []float64, lwork int) {
-	checkMatrix(n, n, a, lda)
 	switch {
 	case ilo < 0 || max(0, n-1) < ilo:
 		panic(badIlo)
 	case ihi < min(ilo, n-1) || n <= ihi:
 		panic(badIhi)
-	case len(work) < lwork:
-		panic(shortWork)
 	case lwork < max(1, n) && lwork != -1:
 		panic(badWork)
-	case n > 0 && len(tau) != n-1 && lwork != -1:
-		panic(badTau)
+	case len(work) < lwork:
+		panic(shortWork)
+	}
+	if lwork != -1 {
+		checkMatrix(n, n, a, lda)
+		if len(tau) != n-1 && n > 0 {
+			panic(badTau)
+		}
 	}
 
 	const (

--- a/native/dlaqr2.go
+++ b/native/dlaqr2.go
@@ -1,0 +1,382 @@
+// Copyright ©2016 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package native
+
+import (
+	"math"
+
+	"github.com/gonum/blas"
+	"github.com/gonum/blas/blas64"
+	"github.com/gonum/lapack"
+)
+
+// Dlaqr2 performs the orthogonal similarity transformation of a n×n upper
+// Hessenberg matrix to detect and deflate fully converged eigenvalues from a
+// trailing principal submatrix using aggressive early deflation [1].
+//
+// On return, H will be overwritten by a new Hessenberg matrix that is a
+// perturbation of an orthogonal similarity transformation of H. It is to be
+// hoped that on output H will have many zero subdiagonal entries.
+//
+// If wantt is true, the matrix H will be fully updated so that the
+// quasi-triangular Schur factor can be computed. If wantt is false, then only
+// enough of H will be updated to preserve the eigenvalues.
+//
+// If wantz is true, the orthogonal similarity transformation will be
+// accumulated into Z[iloz:ihiz+1,ktop:kbot+1], otherwise Z is not referenced.
+//
+// ktop and kbot determine an block [ktop:kbot+1,ktop:kbot+1] along the diagonal
+// of H. The block must be isolated, that is, it must hold that
+//  ktop == 0   or H[ktop,ktop-1] == 0,  and
+//  kbot == n-1 or H[kbot+1,kbot] == 0,
+// otherwise Dlaqr2 will panic.
+//
+// nw is the deflation window size. It must hold that
+//  1 <= nw <= kbot-ktop+1,
+// otherwise Dlaqr2 will panic.
+//
+// iloz and ihiz specify the rows of the n×n matrix Z to which transformations
+// will be applied if wantz is true. It must hold that
+//  0 <= iloz <= ktop,  and  kbot <= ihiz < n,
+// otherwise Dlaqr2 will panic.
+//
+// sr and si must have length kbot+1, otherwise Dlaqr2 will panic.
+//
+// v and ldv represent an nw×nw work matrix.
+//
+// t and ldt represent an nw×nw work matrix T. nh is the number of columns of T
+// available for workspace. It must hold that nh <= nw, otherwise Dlaqr2 will
+// panic.
+//
+// wv and ldwv represent an nw×nw work matrix W. nv is the number of rows of W
+// available for workspace. It must hold that nv <= nw, otherwise Dlaqr2 will
+// panic.
+//
+// work must have length at least lwork and lwork must be at least max(1,2*nw),
+// otherwise Dlaqr2 will panic. Larger values of lwork may result in greater
+// efficiency. On return, work[0] will contain the optimal value of lwork.
+//
+// If lwork is -1, instead of performing Dlaqr2, the function only estimates the
+// optimal workspace size and stores it into work[0]. Neither h nor z are
+// accessed.
+//
+// On return, ns and nd will contain respectively the number of unconverged
+// (i.e., approximate) eigenvalues and converged eigenvalues that are stored in
+// sr and si.
+//
+// On return, the real and imaginary parts of approximate eigenvalues that may
+// be used for shifts will be stored respectively in sr[kbot-nd-ns+1:kbot-nd+1]
+// and si[kbot-nd-ns+1:kbot-nd+1].
+//
+// On return, the real and imaginary parts of converged eigenvalues will be
+// stored respectively in sr[kbot-nd+1:kbot+1] and si[kbot-nd+1:kbot+1].
+//
+// References:
+//  [1] K. Braman, R. Byers, R. Mathias. The Multishift QR Algorithm. Part II:
+//      Aggressive Early Deflation. SIAM J. Matrix Anal. Appl 23(4) (2002), pp. 948—973
+//      URL: http://dx.doi.org/10.1137/S0895479801384585
+//
+func (impl Implementation) Dlaqr2(wantt, wantz bool, n, ktop, kbot, nw int, h []float64, ldh int, iloz, ihiz int, z []float64, ldz int, sr, si []float64, v []float64, ldv int, nh int, t []float64, ldt int, nv int, wv []float64, ldwv int, work []float64, lwork int) (ns, nd int) {
+	checkMatrix(n, n, h, ldh)
+	switch {
+	case ktop < 0 || ktop > max(0, n-1):
+		panic("lapack: invalid value of ktop")
+	case kbot < min(ktop, n-1) || n <= kbot:
+		panic("lapack: invalid value of kbot")
+	case ktop >= 1 && h[ktop*ldh+ktop-1] != 0:
+		panic("lapack: block not isolated")
+	case kbot+1 < n && h[(kbot+1)*ldh+kbot] != 0:
+		panic("lapack: block not isolated")
+	case nw < 0 || kbot-ktop+1 < nw:
+		panic("lapack: invalid value of nw")
+	}
+	if wantz {
+		checkMatrix(n, n, z, ldz)
+		switch {
+		case iloz < 0 || ktop < iloz:
+			panic("lapack: invalid value of iloz")
+		case ihiz < kbot || n <= ihiz:
+			panic("lapack: invalid value of ihiz")
+		}
+	}
+	checkMatrix(nw, nw, v, ldv)
+	checkMatrix(nw, nw, t, ldt)
+	checkMatrix(nw, nw, wv, ldwv)
+	switch {
+	case nh > nw:
+		panic("lapack: invalid value of nh")
+	case nv > nw:
+		panic("lapack: invalid value of nv")
+	case len(sr) != kbot+1:
+		panic("lapack: bad length of sr")
+	case len(si) != kbot+1:
+		panic("lapack: bad length of si")
+	case len(work) < lwork:
+		panic(shortWork)
+	case lwork != -1 && lwork < max(1, 2*nw):
+		panic(badWork)
+	}
+
+	// LAPACK code does not enforce the documented behavior
+	//  nw <= kbot-ktop+1
+	// but we do (we panic above).
+	jw := nw
+	lwkopt := max(1, 2*nw)
+	if jw > 2 {
+		// Workspace query call to Dgehrd.
+		impl.Dgehrd(jw, 0, jw-2, t, ldt, nil, work, -1)
+		lwk1 := int(work[0])
+		// Workspace query call to Dormhr.
+		impl.Dormhr(blas.Right, blas.NoTrans, jw, jw, 0, jw-2, t, ldt, work, v, ldv, work, -1)
+		lwk2 := int(work[0])
+		// Optimal workspace.
+		lwkopt = jw + max(lwk1, lwk2)
+	}
+
+	// Quick return in case of workspace query.
+	if lwork == -1 {
+		work[0] = float64(lwkopt)
+		return 0, 0
+	}
+
+	if nw == 0 {
+		return
+	}
+
+	// Machine constants.
+	ulp := dlamchP
+	smlnum := float64(n) / ulp * dlamchS
+
+	// Setup deflation window.
+	var s float64
+	kwtop := kbot - jw + 1
+	if kwtop != ktop {
+		s = h[kwtop*ldh+kwtop-1]
+	}
+	if kwtop == kbot {
+		// 1×1 deflation window.
+		sr[kwtop] = h[kwtop*ldh+kwtop]
+		si[kwtop] = 0
+		ns = 1
+		nd = 0
+		if math.Abs(s) <= math.Max(smlnum, ulp*math.Abs(h[kwtop*ldh+kwtop])) {
+			ns = 0
+			nd = 1
+			if kwtop > ktop {
+				h[kwtop*ldh+kwtop-1] = 0
+			}
+		}
+		work[0] = 1
+		return ns, nd
+	}
+
+	// Convert to spike-triangular form. In case of a rare QR failure, this
+	// routine continues to do aggressive early deflation using that part of
+	// the deflation window that converged using infqr here and there to
+	// keep track.
+	impl.Dlacpy(blas.Upper, jw, jw, h[kwtop*ldh+kwtop:], ldh, t, ldt)
+	bi := blas64.Implementation()
+	bi.Dcopy(jw-1, h[(kwtop+1)*ldh+kwtop:], ldh+1, t[ldt:], ldt+1)
+	impl.Dlaset(blas.All, jw, jw, 0, 1, v, ldv)
+	infqr := impl.Dlahqr(true, true, jw, 0, jw-1, t, ldt, sr[kwtop:], si[kwtop:], 0, jw-1, v, ldv)
+	// Note that ilo == 0 which conveniently coincides with the success
+	// value of infqr, that is, infqr as an index always points to the first
+	// converged eigenvalue.
+
+	// Dtrexc needs a clean margin near the diagonal.
+	for j := 0; j < jw-3; j++ {
+		t[(j+2)*ldt+j] = 0
+		t[(j+3)*ldt+j] = 0
+	}
+	if jw >= 3 {
+		t[(jw-1)*ldt+jw-3] = 0
+	}
+
+	ns = jw
+	ilst := infqr
+	// Deflation detection loop.
+	for ilst < ns {
+		var bulge bool
+		if ns >= 2 {
+			bulge = t[(ns-1)*ldt+ns-2] != 0
+		}
+		if !bulge {
+			// Real eigenvalue.
+			abst := math.Abs(t[(ns-1)*ldt+ns-1])
+			if abst == 0 {
+				abst = math.Abs(s)
+			}
+			if math.Abs(s*v[ns-1]) <= math.Max(smlnum, ulp*abst) {
+				// Deflatable.
+				ns--
+			} else {
+				// Undeflatable, move it up out of the way.
+				// Dtrexc can not fail in this case.
+				_, ilst, _ = impl.Dtrexc(lapack.EigDecomp, jw, t, ldt, v, ldv, ns-1, ilst, work)
+				ilst++
+			}
+			continue
+		}
+		// Complex conjugate pair.
+		abst := math.Abs(t[(ns-1)*ldt+ns-1]) + math.Sqrt(math.Abs(t[(ns-1)*ldt+ns-2]))*math.Sqrt(math.Abs(t[(ns-2)*ldt+ns-1]))
+		if abst == 0 {
+			abst = math.Abs(s)
+		}
+		if math.Max(math.Abs(s*v[ns-1]), math.Abs(s*v[ns-2])) <= math.Max(smlnum, ulp*abst) {
+			// Deflatable.
+			ns -= 2
+		} else {
+			// Undeflatable, move them up out of the way.
+			// Dtrexc does the right thing with ilst in case of a
+			// rare exchange failure.
+			_, ilst, _ = impl.Dtrexc(lapack.EigDecomp, jw, t, ldt, v, ldv, ns-1, ilst, work)
+			ilst += 2
+		}
+	}
+
+	// Return to Hessenberg form.
+	if ns == 0 {
+		s = 0
+	}
+	if ns < jw {
+		// Sorting diagonal blocks of T improves accuracy for graded
+		// matrices. Bubble sort deals well with exchange failures.
+		sorted := false
+		i := ns
+		for !sorted {
+			sorted = true
+			kend := i - 1
+			i = infqr
+			var k int
+			if i == ns-1 || t[(i+1)*ldt+i] == 0 {
+				k = i + 1
+			} else {
+				k = i + 2
+			}
+			for k <= kend {
+				var evi float64
+				if k == i+1 {
+					evi = math.Abs(t[i*ldt+i])
+				} else {
+					evi = math.Abs(t[i*ldt+i]) + math.Sqrt(math.Abs(t[(i+1)*ldt+i]))*math.Sqrt(math.Abs(t[i*ldt+i+1]))
+				}
+
+				var evk float64
+				if k == kend || t[(k+1)*ldt+k] == 0 {
+					evk = math.Abs(t[k*ldt+k])
+				} else {
+					evk = math.Abs(t[k*ldt+k]) + math.Sqrt(math.Abs(t[(k+1)*ldt+k]))*math.Sqrt(math.Abs(t[k*ldt+k+1]))
+				}
+
+				if evi >= evk {
+					i = k
+				} else {
+					sorted = false
+					_, ilst, ok := impl.Dtrexc(lapack.EigDecomp, jw, t, ldt, v, ldv, i, k, work)
+					if ok {
+						i = ilst
+					} else {
+						i = k
+					}
+				}
+				if i == kend || t[(i+1)*ldt+i] == 0 {
+					k = i + 1
+				} else {
+					k = i + 2
+				}
+			}
+		}
+	}
+
+	// Restore shift/eigenvalue array from T.
+	for i := jw - 1; i >= infqr; {
+		if i == infqr || t[i*ldt+i-1] == 0 {
+			sr[kwtop+i] = t[i*ldt+i]
+			si[kwtop+i] = 0
+			i--
+			continue
+		}
+		aa := t[(i-1)*ldt+i-1]
+		bb := t[(i-1)*ldt+i]
+		cc := t[i*ldt+i-1]
+		dd := t[i*ldt+i]
+		_, _, _, _, sr[kwtop+i-1], si[kwtop+i-1], sr[kwtop+i], si[kwtop+i], _, _ = impl.Dlanv2(aa, bb, cc, dd)
+		i -= 2
+	}
+
+	if ns < jw || s == 0 {
+		if ns > 1 && s != 0 {
+			// Reflect spike back into lower triangle.
+			bi.Dcopy(ns, v[:ns], 1, work[:ns], 1)
+			_, tau := impl.Dlarfg(ns, work[0], work[1:ns], 1)
+			work[0] = 1
+			impl.Dlaset(blas.Lower, jw-2, jw-2, 0, 0, t[2*ldt:], ldt)
+			impl.Dlarf(blas.Left, ns, jw, work[:ns], 1, tau, t, ldt, work[jw:])
+			impl.Dlarf(blas.Right, ns, ns, work[:ns], 1, tau, t, ldt, work[jw:])
+			impl.Dlarf(blas.Right, jw, ns, work[:ns], 1, tau, v, ldv, work[jw:])
+			impl.Dgehrd(jw, 0, ns-1, t, ldt, work[:jw-1], work[jw:], lwork-jw)
+		}
+
+		// Copy updated reduced window into place.
+		if kwtop >= 1 {
+			h[kwtop*ldh+kwtop-1] = s * v[0]
+		}
+		impl.Dlacpy(blas.Upper, jw, jw, t, ldt, h[kwtop*ldh+kwtop:], ldh)
+		bi.Dcopy(jw-1, t[ldt:], ldt+1, h[(kwtop+1)*ldh+kwtop:], ldh+1)
+
+		// Accumulate orthogonal matrix in order to update H and Z, if
+		// requested.
+		if ns > 1 && s != 0 {
+			// work[:ns-1] contains the elementary reflectors stored
+			// by a call to Dgehrd above.
+			impl.Dormhr(blas.Right, blas.NoTrans, jw, ns, 0, ns-1, t, ldt, work[:ns-1], v, ldv, work[jw:], lwork-jw)
+		}
+
+		// Update vertical slab in H.
+		var ltop int
+		if !wantt {
+			ltop = ktop
+		}
+		for krow := ltop; krow < kwtop; krow += nv {
+			kln := min(nv, kwtop-krow)
+			bi.Dgemm(blas.NoTrans, blas.NoTrans, kln, jw, jw,
+				1, h[krow*ldh+kwtop:], ldh, v, ldv,
+				0, wv, ldwv)
+			impl.Dlacpy(blas.All, kln, jw, wv, ldwv, h[krow*ldh+kwtop:], ldh)
+		}
+
+		// Update horizontal slab in H.
+		if wantt {
+			for kcol := kbot + 1; kcol < n; kcol += nh {
+				kln := min(nh, n-kcol)
+				bi.Dgemm(blas.Trans, blas.NoTrans, jw, kln, jw,
+					1, v, ldv, h[kwtop*ldh+kcol:], ldh,
+					0, t, ldt)
+				impl.Dlacpy(blas.All, jw, kln, t, ldt, h[kwtop*ldh+kcol:], ldh)
+			}
+		}
+
+		// Update vertical slab in Z.
+		if wantz {
+			for krow := iloz; krow <= ihiz; krow += nv {
+				kln := min(nv, ihiz-krow+1)
+				bi.Dgemm(blas.NoTrans, blas.NoTrans, kln, jw, jw,
+					1, z[krow*ldz+kwtop:], ldz, v, ldv,
+					0, wv, ldwv)
+				impl.Dlacpy(blas.All, kln, jw, wv, ldwv, z[krow*ldz+kwtop:], ldz)
+			}
+		}
+	}
+
+	// The number of deflations.
+	nd = jw - ns
+	// Shifts are converged eigenvalues that could not be deflated.
+	// Subtracting infqr from the spike length takes care of the case of a
+	// rare QR failure while calculating eigenvalues of the deflation
+	// window.
+	ns -= infqr
+	work[0] = float64(lwkopt)
+	return ns, nd
+}

--- a/native/dlaqr2.go
+++ b/native/dlaqr2.go
@@ -48,14 +48,8 @@ import (
 // sr and si must have length kbot+1, otherwise Dlaqr2 will panic.
 //
 // v and ldv represent an nw×nw work matrix.
-//
-// t and ldt represent an nw×nw work matrix T. nh is the number of columns of T
-// available for workspace. It must hold that nh <= nw, otherwise Dlaqr2 will
-// panic.
-//
-// wv and ldwv represent an nw×nw work matrix W. nv is the number of rows of W
-// available for workspace. It must hold that nv <= nw, otherwise Dlaqr2 will
-// panic.
+// t and ldt represent an nw×nh work matrix, and nh must be at least nw.
+// wv and ldwv represent an nv×nw work matrix.
 //
 // work must have length at least lwork and lwork must be at least max(1,2*nw),
 // otherwise Dlaqr2 will panic. Larger values of lwork may result in greater
@@ -105,13 +99,11 @@ func (impl Implementation) Dlaqr2(wantt, wantz bool, n, ktop, kbot, nw int, h []
 		}
 	}
 	checkMatrix(nw, nw, v, ldv)
-	checkMatrix(nw, nw, t, ldt)
-	checkMatrix(nw, nw, wv, ldwv)
+	checkMatrix(nw, nh, t, ldt)
+	checkMatrix(nv, nw, wv, ldwv)
 	switch {
-	case nh > nw:
+	case nh < nw:
 		panic("lapack: invalid value of nh")
-	case nv > nw:
-		panic("lapack: invalid value of nv")
 	case len(sr) != kbot+1:
 		panic("lapack: bad length of sr")
 	case len(si) != kbot+1:

--- a/native/dormhr.go
+++ b/native/dormhr.go
@@ -64,8 +64,6 @@ func (impl Implementation) Dormhr(side blas.Side, trans blas.Transpose, m, n, il
 	default:
 		panic(badSide)
 	}
-	checkMatrix(m, n, c, ldc)
-	checkMatrix(nq, nq, a, lda)
 	switch {
 	case trans != blas.NoTrans && trans != blas.Trans:
 		panic(badTrans)
@@ -73,12 +71,18 @@ func (impl Implementation) Dormhr(side blas.Side, trans blas.Transpose, m, n, il
 		panic(badIlo)
 	case ihi < min(ilo, nq-1) || nq <= ihi:
 		panic(badIhi)
-	case nq > 0 && len(tau) != nq-1 && lwork != -1:
-		panic(badTau)
 	case lwork < max(1, nw) && lwork != -1:
 		panic(badWork)
 	case len(work) < max(1, lwork):
 		panic(shortWork)
+	}
+	if lwork != -1 {
+		checkMatrix(m, n, c, ldc)
+		checkMatrix(nq, nq, a, lda)
+		if len(tau) != nq-1 && nq > 0 {
+			panic(badTau)
+		}
+
 	}
 
 	nh := ihi - ilo

--- a/native/lapack_test.go
+++ b/native/lapack_test.go
@@ -144,6 +144,10 @@ func TestDlaqr1(t *testing.T) {
 	testlapack.Dlaqr1Test(t, impl)
 }
 
+func TestDlaqr2(t *testing.T) {
+	testlapack.Dlaqr2Test(t, impl)
+}
+
 func TestDlaqr5(t *testing.T) {
 	testlapack.Dlaqr5Test(t, impl)
 }

--- a/testlapack/dgehrd.go
+++ b/testlapack/dgehrd.go
@@ -90,7 +90,7 @@ func testDgehrd(t *testing.T, impl Dgehrder, n, ilo, ihi, extra int, optwork boo
 	var work []float64
 	if optwork {
 		work = nanSlice(1)
-		impl.Dgehrd(n, ilo, ihi, a.Data, a.Stride, tau, work, -1)
+		impl.Dgehrd(n, ilo, ihi, nil, a.Stride, nil, work, -1)
 		work = nanSlice(int(work[0]))
 	} else {
 		work = nanSlice(max(1, n))

--- a/testlapack/dlaqr2.go
+++ b/testlapack/dlaqr2.go
@@ -232,27 +232,27 @@ func testDlaqr2(t *testing.T, impl Dlaqr2er, test dlaqr2Test, opt bool, rnd *ran
 	v := randomGeneral(nw, nw, nw+extra, rnd)
 	var nh int
 	if nw > 0 {
-		nh = rnd.Intn(nw) + 1
+		nh = nw + rnd.Intn(nw) // nh must be at least nw.
 	}
-	tmat := randomGeneral(nw, nw, nw+extra, rnd)
+	tmat := randomGeneral(nw, nh, nh+extra, rnd)
 	var nv int
 	if nw > 0 {
 		nv = rnd.Intn(nw) + 1
 	}
-	wv := randomGeneral(nw, nw, nw+extra, rnd)
+	wv := randomGeneral(nv, nw, nw+extra, rnd)
 
 	var work []float64
 	if opt {
 		work = nanSlice(1)
 		impl.Dlaqr2(wantt, wantz, n, ktop, kbot, nw, h.Data, h.Stride, iloz, ihiz, z.Data, z.Stride,
-			sr, si, v.Data, v.Stride, nh, tmat.Data, tmat.Stride, nv, wv.Data, wv.Stride, work, -1)
+			sr, si, v.Data, v.Stride, tmat.Cols, tmat.Data, tmat.Stride, wv.Rows, wv.Data, wv.Stride, work, -1)
 		work = nanSlice(int(work[0]))
 	} else {
 		work = nanSlice(max(1, 2*nw))
 	}
 
 	ns, nd := impl.Dlaqr2(wantt, wantz, n, ktop, kbot, nw, h.Data, h.Stride, iloz, ihiz, z.Data, z.Stride,
-		sr, si, v.Data, v.Stride, nh, tmat.Data, tmat.Stride, nv, wv.Data, wv.Stride, work, len(work))
+		sr, si, v.Data, v.Stride, tmat.Cols, tmat.Data, tmat.Stride, wv.Rows, wv.Data, wv.Stride, work, len(work))
 
 	prefix := fmt.Sprintf("Case wantt=%v, wantz=%v, n=%v, ktop=%v, kbot=%v, nw=%v, iloz=%v, ihiz=%v, extra=%v",
 		wantt, wantz, n, ktop, kbot, nw, iloz, ihiz, extra)

--- a/testlapack/dlaqr2.go
+++ b/testlapack/dlaqr2.go
@@ -244,8 +244,8 @@ func testDlaqr2(t *testing.T, impl Dlaqr2er, test dlaqr2Test, opt bool, rnd *ran
 	var work []float64
 	if opt {
 		work = nanSlice(1)
-		impl.Dlaqr2(wantt, wantz, n, ktop, kbot, nw, h.Data, h.Stride, iloz, ihiz, z.Data, z.Stride,
-			sr, si, v.Data, v.Stride, tmat.Cols, tmat.Data, tmat.Stride, wv.Rows, wv.Data, wv.Stride, work, -1)
+		impl.Dlaqr2(wantt, wantz, n, ktop, kbot, nw, nil, h.Stride, iloz, ihiz, nil, z.Stride,
+			nil, nil, nil, v.Stride, tmat.Cols, nil, tmat.Stride, wv.Rows, nil, wv.Stride, work, -1)
 		work = nanSlice(int(work[0]))
 	} else {
 		work = nanSlice(max(1, 2*nw))

--- a/testlapack/dlaqr2.go
+++ b/testlapack/dlaqr2.go
@@ -1,0 +1,325 @@
+// Copyright ©2016 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlapack
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/gonum/blas"
+	"github.com/gonum/blas/blas64"
+)
+
+type Dlaqr2er interface {
+	Dlaqr2(wantt, wantz bool, n, ktop, kbot, nw int, h []float64, ldh int, iloz, ihiz int, z []float64, ldz int, sr, si []float64, v []float64, ldv int, nh int, t []float64, ldt int, nv int, wv []float64, ldwv int, work []float64, lwork int) (ns, nd int)
+}
+
+type dlaqr2Test struct {
+	wantt, wantz bool
+	ktop, kbot   int
+	nw           int
+	h            blas64.General
+	iloz, ihiz   int
+
+	evWant []complex128 // Optional slice with known eigenvalues.
+}
+
+func Dlaqr2Test(t *testing.T, impl Dlaqr2er) {
+	rnd := rand.New(rand.NewSource(1))
+
+	for _, wantt := range []bool{true, false} {
+		for _, wantz := range []bool{true, false} {
+			for _, n := range []int{1, 2, 3, 4, 5, 6, 10, 18, 31, 53} {
+				for _, extra := range []int{0, 1, 11} {
+					for cas := 0; cas < 100; cas++ {
+						ktop := rnd.Intn(n)
+						kbot := rnd.Intn(n)
+						if ktop > kbot {
+							ktop, kbot = kbot, ktop
+						}
+						nw := rnd.Intn(kbot-ktop+1) + 1
+						h := randomHessenberg(n, n+extra, rnd)
+						if ktop-1 >= 0 {
+							h.Data[ktop*h.Stride+ktop-1] = 0
+						}
+						if kbot+1 < n {
+							h.Data[(kbot+1)*h.Stride+kbot] = 0
+						}
+						iloz := rnd.Intn(ktop + 1)
+						ihiz := kbot + rnd.Intn(n-kbot)
+						test := dlaqr2Test{
+							wantt: wantt,
+							wantz: wantz,
+							ktop:  ktop,
+							kbot:  kbot,
+							nw:    nw,
+							h:     h,
+							iloz:  iloz,
+							ihiz:  ihiz,
+						}
+						testDlaqr2(t, impl, test, false, rnd)
+						testDlaqr2(t, impl, test, true, rnd)
+					}
+				}
+			}
+		}
+	}
+
+	// Tests with n=0.
+	for _, wantt := range []bool{true, false} {
+		for _, wantz := range []bool{true, false} {
+			for _, extra := range []int{0, 1, 11} {
+				test := dlaqr2Test{
+					wantt: wantt,
+					wantz: wantz,
+					h:     randomHessenberg(0, extra, rnd),
+					ktop:  0,
+					kbot:  -1,
+					iloz:  0,
+					ihiz:  -1,
+					nw:    0,
+				}
+				testDlaqr2(t, impl, test, true, rnd)
+				testDlaqr2(t, impl, test, false, rnd)
+			}
+		}
+	}
+
+	// Tests with explicit eigenvalues computed by Octave.
+	for _, test := range []dlaqr2Test{
+		{
+			h: blas64.General{
+				Rows:   1,
+				Cols:   1,
+				Stride: 1,
+				Data:   []float64{7.09965484086874e-1},
+			},
+			ktop:   0,
+			kbot:   0,
+			iloz:   0,
+			ihiz:   0,
+			evWant: []complex128{7.09965484086874e-1},
+		},
+		{
+			h: blas64.General{
+				Rows:   2,
+				Cols:   2,
+				Stride: 2,
+				Data: []float64{
+					0, -1,
+					1, 0,
+				},
+			},
+			ktop:   0,
+			kbot:   1,
+			iloz:   0,
+			ihiz:   1,
+			evWant: []complex128{1i, -1i},
+		},
+		{
+			h: blas64.General{
+				Rows:   2,
+				Cols:   2,
+				Stride: 2,
+				Data: []float64{
+					6.25219991450918e-1, 8.17510791994361e-1,
+					3.31218891622294e-1, 1.24103744878131e-1,
+				},
+			},
+			ktop:   0,
+			kbot:   1,
+			iloz:   0,
+			ihiz:   1,
+			evWant: []complex128{9.52203547663447e-1, -2.02879811334398e-1},
+		},
+		{
+			h: blas64.General{
+				Rows:   4,
+				Cols:   4,
+				Stride: 4,
+				Data: []float64{
+					1, 0, 0, 0,
+					0, 6.25219991450918e-1, 8.17510791994361e-1, 0,
+					0, 3.31218891622294e-1, 1.24103744878131e-1, 0,
+					0, 0, 0, 1,
+				},
+			},
+			ktop:   1,
+			kbot:   2,
+			iloz:   0,
+			ihiz:   3,
+			evWant: []complex128{9.52203547663447e-1, -2.02879811334398e-1},
+		},
+		{
+			h: blas64.General{
+				Rows:   2,
+				Cols:   2,
+				Stride: 2,
+				Data: []float64{
+					-1.1219562276608, 6.85473513349362e-1,
+					-8.19951061145131e-1, 1.93728523178888e-1,
+				},
+			},
+			ktop: 0,
+			kbot: 1,
+			iloz: 0,
+			ihiz: 1,
+			evWant: []complex128{
+				-4.64113852240958e-1 + 3.59580510817350e-1i,
+				-4.64113852240958e-1 - 3.59580510817350e-1i,
+			},
+		},
+		{
+			h: blas64.General{
+				Rows:   5,
+				Cols:   5,
+				Stride: 5,
+				Data: []float64{
+					9.57590178533658e-1, -5.10651295522708e-1, 9.24974510015869e-1, -1.30016306879522e-1, 2.92601986926954e-2,
+					-1.08084756637964, 1.77529701001213, -1.36480197632509, 2.23196371219601e-1, 1.12912853063308e-1,
+					0, -8.44075612174676e-1, 1.067867614486, -2.55782915176399e-1, -2.00598563137468e-1,
+					0, 0, -5.67097237165410e-1, 2.07205057427341e-1, 6.54998340743380e-1,
+					0, 0, 0, -1.89441413886041e-1, -4.18125416021786e-1,
+				},
+			},
+			ktop: 0,
+			kbot: 4,
+			iloz: 0,
+			ihiz: 4,
+			evWant: []complex128{
+				2.94393309555622,
+				4.97029793606701e-1 + 3.63041654992384e-1i,
+				4.97029793606701e-1 - 3.63041654992384e-1i,
+				-1.74079119166145e-1 + 2.01570009462092e-1i,
+				-1.74079119166145e-1 - 2.01570009462092e-1i,
+			},
+		},
+	} {
+		test.wantt = true
+		test.wantz = true
+		test.nw = test.kbot - test.ktop + 1
+		testDlaqr2(t, impl, test, true, rnd)
+		testDlaqr2(t, impl, test, false, rnd)
+	}
+}
+
+func testDlaqr2(t *testing.T, impl Dlaqr2er, test dlaqr2Test, opt bool, rnd *rand.Rand) {
+	const tol = 1e-14
+
+	h := cloneGeneral(test.h)
+	n := h.Cols
+	extra := h.Stride - h.Cols
+	wantt := test.wantt
+	wantz := test.wantz
+	ktop := test.ktop
+	kbot := test.kbot
+	nw := test.nw
+	iloz := test.iloz
+	ihiz := test.ihiz
+
+	var z, zCopy blas64.General
+	if wantz {
+		z = eye(n, n+extra)
+		zCopy = cloneGeneral(z)
+	}
+
+	sr := nanSlice(kbot + 1)
+	si := nanSlice(kbot + 1)
+
+	v := randomGeneral(nw, nw, nw+extra, rnd)
+	var nh int
+	if nw > 0 {
+		nh = rnd.Intn(nw) + 1
+	}
+	tmat := randomGeneral(nw, nw, nw+extra, rnd)
+	var nv int
+	if nw > 0 {
+		nv = rnd.Intn(nw) + 1
+	}
+	wv := randomGeneral(nw, nw, nw+extra, rnd)
+
+	var work []float64
+	if opt {
+		work = nanSlice(1)
+		impl.Dlaqr2(wantt, wantz, n, ktop, kbot, nw, h.Data, h.Stride, iloz, ihiz, z.Data, z.Stride,
+			sr, si, v.Data, v.Stride, nh, tmat.Data, tmat.Stride, nv, wv.Data, wv.Stride, work, -1)
+		work = nanSlice(int(work[0]))
+	} else {
+		work = nanSlice(max(1, 2*nw))
+	}
+
+	ns, nd := impl.Dlaqr2(wantt, wantz, n, ktop, kbot, nw, h.Data, h.Stride, iloz, ihiz, z.Data, z.Stride,
+		sr, si, v.Data, v.Stride, nh, tmat.Data, tmat.Stride, nv, wv.Data, wv.Stride, work, len(work))
+
+	prefix := fmt.Sprintf("Case wantt=%v, wantz=%v, n=%v, ktop=%v, kbot=%v, nw=%v, iloz=%v, ihiz=%v, extra=%v",
+		wantt, wantz, n, ktop, kbot, nw, iloz, ihiz, extra)
+
+	if !generalOutsideAllNaN(h) {
+		t.Errorf("%v: out-of-range write to H\n%v", prefix, h.Data)
+	}
+	if !generalOutsideAllNaN(z) {
+		t.Errorf("%v: out-of-range write to Z\n%v", prefix, z.Data)
+	}
+	if !generalOutsideAllNaN(v) {
+		t.Errorf("%v: out-of-range write to V\n%v", prefix, v.Data)
+	}
+	if !generalOutsideAllNaN(tmat) {
+		t.Errorf("%v: out-of-range write to T\n%v", prefix, tmat.Data)
+	}
+	if !generalOutsideAllNaN(wv) {
+		t.Errorf("%v: out-of-range write to WV\n%v", prefix, wv.Data)
+	}
+	if !isAllNaN(sr[:kbot-nd-ns+1]) || !isAllNaN(sr[kbot+1:]) {
+		t.Errorf("%v: out-of-range write to sr")
+	}
+	if !isAllNaN(si[:kbot-nd-ns+1]) || !isAllNaN(si[kbot+1:]) {
+		t.Errorf("%v: out-of-range write to si")
+	}
+
+	if !isUpperHessenberg(h) {
+		t.Errorf("%v: H is not upper Hessenberg", prefix)
+	}
+
+	if test.evWant != nil {
+		for i := kbot - nd + 1; i <= kbot; i++ {
+			ev := complex(sr[i], si[i])
+			if !containsComplex(test.evWant, ev, tol) {
+				t.Errorf("%v: unexpected eigenvalue %v", prefix, ev)
+			}
+		}
+	}
+
+	if !wantz {
+		return
+	}
+
+	var zmod bool
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if z.Data[i*z.Stride+j] == zCopy.Data[i*zCopy.Stride+j] {
+				continue
+			}
+			if i < iloz || i > ihiz || j < kbot-nw+1 || j > kbot {
+				zmod = true
+			}
+		}
+	}
+	if zmod {
+		t.Errorf("%v: unexpected modification of Z", prefix)
+	}
+	if !isOrthonormal(z) {
+		t.Errorf("%v: Z is not orthogonal", prefix)
+	}
+	if wantt {
+		hu := eye(n, n)
+		blas64.Gemm(blas.NoTrans, blas.NoTrans, 1, test.h, z, 0, hu)
+		uhu := eye(n, n)
+		blas64.Gemm(blas.Trans, blas.NoTrans, 1, z, hu, 0, uhu)
+		if !equalApproxGeneral(uhu, h, 10*tol) {
+			t.Errorf("%v: Z^T*(initial H)*Z and (final H) are not equal", prefix)
+		}
+	}
+}

--- a/testlapack/dormhr.go
+++ b/testlapack/dormhr.go
@@ -107,7 +107,7 @@ func testDormhr(t *testing.T, impl Dormhrer, side blas.Side, trans blas.Transpos
 	// Compute the product of Q and C using Dormhr.
 	if optwork {
 		work = nanSlice(1)
-		impl.Dormhr(side, trans, m, n, ilo, ihi, a.Data, a.Stride, tau, c.Data, c.Stride, work, -1)
+		impl.Dormhr(side, trans, m, n, ilo, ihi, nil, a.Stride, nil, nil, c.Stride, work, -1)
 		work = nanSlice(int(work[0]))
 	} else {
 		work = nanSlice(max(1, nw))


### PR DESCRIPTION
The documentation of reference DLAQR2 is quite loose or even incorrect in some places, so most of the differences in this PR come from that. Further, some of the documented restrictions on input values are in fact allowed and handled in the reference, I'm stricter and usually panic. That's another source of tiny differences.

Also, it seems that having a set of matrices with known eigenvalues will be soon very useful / necessary for testing. Any suggestions on where to get them, and how and where to store them? Using random matrices and computing their eigenvalues in e.g. Octave is of course possible but I'm after "difficult" eigenvalue problems that would trigger some exceptional paths in the code not taken by random matrices. Matrix Market is an option, their matrices for eigenvalue problems seem to be all sparse which should not be a problem for moderate sizes. Any other options?