### PR TITLE
travis: remove testlapack from coverage testing

### DIFF
--- a/.travis/linux/OpenBLAS/install.sh
+++ b/.travis/linux/OpenBLAS/install.sh
@@ -51,10 +51,9 @@ fi
 sudo cp -r ${CACHE_DIR}/* /usr/
 
 # install gonum/blas against OpenBLAS
-# fetch and install gonum/blas and gonum/matrix
+# fetch and install gonum/blas
 export CGO_LDFLAGS="-L/usr/lib -lopenblas"
 go get github.com/gonum/blas
-go get github.com/gonum/matrix/mat64
 
 # install lapacke against OpenBLAS
 pushd cgo/lapacke

--- a/.travis/linux/gonum/install.sh
+++ b/.travis/linux/gonum/install.sh
@@ -1,8 +1,7 @@
 set -ex
 
-# fetch gonum/blas and gonum/matrix
-go get github.com/gonum/blas
-go get github.com/gonum/matrix/mat64
+# fetch gonum/blas
+go get github.com/gonum/blas/native
 
 # travis compiles commands in script and then executes in bash.  By adding
 # set -e we are changing the travis build script's behavior, and the set

--- a/.travis/test-coverage.sh
+++ b/.travis/test-coverage.sh
@@ -27,8 +27,8 @@ testCover() {
 # Init acc.out
 echo "mode: set" > $ACC_OUT
 
-# Run test coverage on all directories containing go files
-find . -maxdepth 10 -type d | while read d; do testCover $d || exit; done
+# Run test coverage on all directories containing go files except testlapack.
+find . -maxdepth 10 -type d -not -path './testlapack*' | while read d; do testCover $d || exit; done
 
 # Upload the coverage profile to coveralls.io
 [ -n "$COVERALLS_TOKEN" ] && goveralls -coverprofile=$ACC_OUT -service=travis-ci -repotoken $COVERALLS_TOKEN


### PR DESCRIPTION
Adding two tests in testlapack package recently triggered the whole testlapack package to be included in coverage testing. As a result, our official coverage dropped from about 80% to about 30%. This PR removes testlapack package from coverage testing. @jonlawlor @kortschak PTAL

I also remove two unnecessary calls to go get mat64. Also, native package is tested twice, once with BLAS_LIB=gonum and once with BLAS_LIB=OpenBLAS (and then both again when doing coverage). However, I don't think that this changes the BLAS library used because in native we use blas64, its default implementation is blas/native and this is not changed by linking against OpenBLAS. Am I missing something or could we speed up the travis tests by not testing native twice?